### PR TITLE
Updated Docker Tag Logic

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Test
         run: |
-          LATEST_TAG=$( \
+          export LATEST_TAG=$( \
               curl -I https://github.com/icecube/skymap_scanner/releases/latest \
               | awk -F '/' '/^location/ {print  substr($NF, 1, length($NF)-1)}' \
               | sed 's/v//' \

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -31,20 +31,16 @@ jobs:
     steps:
       # dependabot can't access normal secrets
       #   & don't run non-branch triggers (like tags)
-      #   & we don't want to trigger an update on PR's merge to main/master/default (which is a branch)
-      # IOW: only for non-dependabot branches
       - if: |
           github.actor != 'dependabot[bot]' &&
-          github.ref_type == 'branch' &&
-          format('refs/heads/{0}', github.event.repository.default_branch) != github.ref
+          github.ref_type == 'branch'
         name: checkout (only for non-dependabot non-default branches)
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - if: |
           github.actor != 'dependabot[bot]' &&
-          github.ref_type == 'branch' &&
-          format('refs/heads/{0}', github.event.repository.default_branch) != github.ref
+          github.ref_type == 'branch'
         name: wipac-dev-py-setup-action (only for non-dependabot non-default branches)
         uses: WIPACrepo/wipac-dev-py-setup-action@v1.11
         with:

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -111,6 +111,12 @@ jobs:
 
       - name: Test
         run: |
+          LATEST_TAG=$( \
+              curl -I https://github.com/icecube/skymap_scanner/releases/latest \
+              | awk -F '/' '/^location/ {print  substr($NF, 1, length($NF)-1)}' \
+              | sed 's/v//' \
+          )
+          echo $LATEST_TAG  # this tag may be off if there's a delay between GH release & docker hub
           pytest -vvv tests/integration
 
       - name: Dump logs

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -4,7 +4,7 @@ on: [push]
 
 env:
   CI_TEST: 'yes'
-  CLIENTMANAGER_IMAGE_TAG: 'latest'
+  CLIENTMANAGER_IMAGE_WITH_TAG: 'ghcr.io/wipacrepo/skydriver:latest'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -51,7 +51,6 @@ jobs:
           base-keywords: WIPAC IceCube
 
   py-versions:
-    needs: [py-setup]
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.versions.outputs.matrix }}

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -117,6 +117,7 @@ jobs:
               | sed 's/v//' \
           )
           echo $LATEST_TAG  # this tag may be off if there's a delay between GH release & docker hub
+          touch tests/resources/mock-cvmfs-images/skymap_scanner:$LATEST_TAG
           pytest -vvv tests/integration
 
       - name: Dump logs

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -117,7 +117,6 @@ jobs:
               | sed 's/v//' \
           )
           echo $LATEST_TAG  # this tag may be off if there's a delay between GH release & docker hub
-          touch tests/resources/mock-cvmfs-images/skymap_scanner:$LATEST_TAG
           pytest -vvv tests/integration
 
       - name: Dump logs

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -4,6 +4,7 @@ on: [push]
 
 env:
   CI_TEST: 'yes'
+  CLIENTMANAGER_IMAGE_TAG: 'latest'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/requirements-clientmanager.txt
+++ b/requirements-clientmanager.txt
@@ -139,7 +139,7 @@ typing-extensions==4.5.0
     #   qrcode
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==1.26.14
+urllib3==1.26.15
     # via
     #   kubernetes
     #   requests

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -32,7 +32,7 @@ deprecated==1.2.13
     # via opentelemetry-api
 dnspython==2.3.0
     # via pymongo
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
 google-auth==2.16.2
     # via kubernetes
@@ -160,7 +160,7 @@ typing-extensions==4.5.0
     #   qrcode
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==1.26.14
+urllib3==1.26.15
     # via
     #   kubernetes
     #   requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -137,7 +137,7 @@ typing-extensions==4.5.0
     #   qrcode
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==1.26.14
+urllib3==1.26.15
     # via
     #   kubernetes
     #   requests

--- a/skydriver/config.py
+++ b/skydriver/config.py
@@ -29,9 +29,6 @@ class EnvConfig:
     CI_TEST: bool = False
     LOG_LEVEL: str = "DEBUG"
 
-    # clientmanager
-    CLIENTMANAGER_IMAGE_WITH_TAG: str = "ghcr.io/wipacrepo/skydriver:latest"
-
     # k8s
     K8S_NAMESPACE: str = ""
     K8S_SECRET_NAME: str = ""

--- a/skydriver/config.py
+++ b/skydriver/config.py
@@ -29,7 +29,7 @@ class EnvConfig:
     CI_TEST: bool = False
     LOG_LEVEL: str = "DEBUG"
 
-    CLIENTMANAGER_IMAGE_TAG: str = ""
+    CLIENTMANAGER_IMAGE_WITH_TAG: str = ""
 
     # k8s
     K8S_NAMESPACE: str = ""
@@ -57,9 +57,9 @@ class EnvConfig:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "LOG_LEVEL", self.LOG_LEVEL.upper())  # b/c frozen
-        if not self.CLIENTMANAGER_IMAGE_TAG:
+        if not self.CLIENTMANAGER_IMAGE_WITH_TAG:
             raise RuntimeError(
-                "Missing required environment variable: 'CLIENTMANAGER_IMAGE_TAG'"
+                "Missing required environment variable: 'CLIENTMANAGER_IMAGE_WITH_TAG'"
             )
 
 

--- a/skydriver/config.py
+++ b/skydriver/config.py
@@ -29,6 +29,8 @@ class EnvConfig:
     CI_TEST: bool = False
     LOG_LEVEL: str = "DEBUG"
 
+    CLIENTMANAGER_IMAGE_TAG: str = ""
+
     # k8s
     K8S_NAMESPACE: str = ""
     K8S_SECRET_NAME: str = ""
@@ -55,6 +57,10 @@ class EnvConfig:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "LOG_LEVEL", self.LOG_LEVEL.upper())  # b/c frozen
+        if not self.CLIENTMANAGER_IMAGE_TAG:
+            raise RuntimeError(
+                "Missing required environment variable: 'CLIENTMANAGER_IMAGE_TAG'"
+            )
 
 
 ENV = from_environment_as_dataclass(EnvConfig)

--- a/skydriver/config.py
+++ b/skydriver/config.py
@@ -46,12 +46,6 @@ class EnvConfig:
     KEYCLOAK_CLIENT_ID_SKYDRIVER_REST: str = ""
     KEYCLOAK_CLIENT_SECRET_SKYDRIVER_REST: str = ""
 
-    # skyscan (meta)
-    SKYSCAN_DOCKER_IMAGE_NO_TAG: str = "icecube/skymap_scanner"
-    SKYSCAN_SINGULARITY_IMAGE_PATH_NO_TAG: str = (
-        "/cvmfs/icecube.opensciencegrid.org/containers/realtime/skymap_scanner"
-    )
-
     # skyscan (forwarded)
     SKYSCAN_BROKER_ADDRESS: str = "localhost"
     # TODO: see https://github.com/WIPACrepo/wipac-dev-tools/pull/69
@@ -64,16 +58,6 @@ class EnvConfig:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "LOG_LEVEL", self.LOG_LEVEL.upper())  # b/c frozen
-        if (
-            self.SKYSCAN_DOCKER_IMAGE_NO_TAG.split("/")[-1]
-            != self.SKYSCAN_SINGULARITY_IMAGE_PATH_NO_TAG.split("/")[-1]
-        ):
-            raise RuntimeError(
-                f"Image Mismatch: "
-                f"'SKYSCAN_DOCKER_IMAGE_NO_TAG' ({self.SKYSCAN_DOCKER_IMAGE_NO_TAG}) and "
-                f"'SKYSCAN_SINGULARITY_IMAGE_PATH_NO_TAG' ({self.SKYSCAN_SINGULARITY_IMAGE_PATH_NO_TAG}) "
-                f"do not reference the same image"
-            )
 
 
 ENV = from_environment_as_dataclass(EnvConfig)

--- a/skydriver/database/interface.py
+++ b/skydriver/database/interface.py
@@ -141,7 +141,7 @@ class ScanIDCollectionFacade:
             # enforce schema
             for key, value in update.items():
                 try:
-                    check_type(key, value, fields[key].type)  # TypeError, KeyError
+                    check_type(value, fields[key].type)  # TypeError, KeyError
                 except (TypeError, KeyError) as e:
                     raise web.HTTPError(
                         500,

--- a/skydriver/database/interface.py
+++ b/skydriver/database/interface.py
@@ -157,7 +157,7 @@ class ScanIDCollectionFacade:
         else:
             try:  # validate via dataclass's `@typechecked` wrapper
                 doc = await find_one_and_update(dc.asdict(update))
-            except (typeguard.TypeCheckError, KeyError) as e:
+            except typeguard.TypeCheckError as e:
                 LOGGER.error(e)
                 raise web.HTTPError(
                     422,

--- a/skydriver/database/interface.py
+++ b/skydriver/database/interface.py
@@ -3,6 +3,7 @@
 import dataclasses as dc
 from typing import Any, AsyncIterator, Type, TypeVar
 
+import typeguard
 from dacite import from_dict  # type: ignore[attr-defined]
 from motor.motor_asyncio import (  # type: ignore
     AsyncIOMotorClient,
@@ -10,7 +11,6 @@ from motor.motor_asyncio import (  # type: ignore
 )
 from pymongo import DESCENDING, ReturnDocument
 from tornado import web
-from typeguard import check_type
 
 from ..config import LOGGER
 from . import schema
@@ -141,18 +141,29 @@ class ScanIDCollectionFacade:
             # enforce schema
             for key, value in update.items():
                 try:
-                    check_type(value, fields[key].type)  # TypeError, KeyError
-                except (TypeError, KeyError) as e:
+                    typeguard.check_type(value, fields[key].type)  # TypeError, KeyError
+                except (typeguard.TypeCheckError, KeyError) as e:
+                    LOGGER.error(e)
+                    msg = f"Invalid type (field '{key}')"
                     raise web.HTTPError(
-                        500,
-                        log_message=f"{e} [{coll=}, {scan_id=}]",
+                        422,
+                        log_message=msg + f" for {scan_id=}",
+                        reason=msg,
                     )
             # at this point we know all data is type checked, so transform & put in DB
             doc = await find_one_and_update(friendly_nested_asdict(update))
             out_type = dclass
         # WHOLE UPDATE
         else:
-            doc = await find_one_and_update(dc.asdict(update))  # validate via dataclass
+            try:  # validate via dataclass's `@typechecked` wrapper
+                doc = await find_one_and_update(dc.asdict(update))
+            except (typeguard.TypeCheckError, KeyError) as e:
+                LOGGER.error(e)
+                raise web.HTTPError(
+                    422,
+                    log_message=f"Invalid type for {scan_id=}",
+                    reason="Invalid type",
+                )
             out_type = type(update)
 
         # upsert

--- a/skydriver/database/schema.py
+++ b/skydriver/database/schema.py
@@ -8,7 +8,7 @@ from typeguard import typechecked
 StrDict = dict[str, Any]
 
 
-@typechecked(always=True)  # always b/c we want full data validation
+@typechecked
 @dc.dataclass
 class ScanIDDataclass:
     """A dataclass with a scan id."""
@@ -17,7 +17,7 @@ class ScanIDDataclass:
     is_deleted: bool
 
 
-@typechecked(always=True)  # always b/c we want full data validation
+@typechecked
 @dc.dataclass
 class ProgressProcessingStats:
     """Details about the scan processing."""
@@ -30,7 +30,7 @@ class ProgressProcessingStats:
     predictions: StrDict = dc.field(default_factory=dict)  # open to requestor
 
 
-@typechecked(always=True)  # always b/c we want full data validation
+@typechecked
 @dc.dataclass
 class Progress:
 
@@ -40,7 +40,7 @@ class Progress:
     processing_stats: ProgressProcessingStats
 
 
-@typechecked(always=True)  # always b/c we want full data validation
+@typechecked
 @dc.dataclass
 class Result(ScanIDDataclass):
     """Encompasses the physics results for a scan."""
@@ -57,7 +57,7 @@ class Result(ScanIDDataclass):
         return rep
 
 
-@typechecked(always=True)  # always b/c we want full data validation
+@typechecked
 @dc.dataclass
 class EventMetadata:
     """Encapsulates the identity of an event."""
@@ -69,7 +69,7 @@ class EventMetadata:
     is_real_event: bool  # as opposed to simulation
 
 
-@typechecked(always=True)  # always b/c we want full data validation
+@typechecked
 @dc.dataclass
 class CondorClutser:
     """Stores information provided by HTCondor."""
@@ -80,7 +80,7 @@ class CondorClutser:
     jobs: int
 
 
-@typechecked(always=True)  # always b/c we want full data validation
+@typechecked
 @dc.dataclass
 class Manifest(ScanIDDataclass):
     """Encapsulates the manifest of a unique scan entity."""

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import cachetools.func
 import requests
 
-from .config import ENV, LOGGER
+from .config import LOGGER
 
 # ---------------------------------------------------------------------------------------
 # constants

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import cachetools.func
 import requests
 
-from .config import LOGGER
+from .config import ENV, LOGGER
 
 # ---------------------------------------------------------------------------------------
 # constants
@@ -26,6 +26,9 @@ _SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH = Path(
 VERSION_REGEX_MAJMINPATCH = re.compile(r"\d+\.\d+\.\d+")
 VERSION_REGEX_PREFIX_V = re.compile(r"v\d+(\.\d+(\.\d+)?)?")
 
+# clientmanager
+_CLIENTMANAGER_IMAGE_NO_TAG = "ghcr.io/wipacrepo/skydriver"
+
 
 # ---------------------------------------------------------------------------------------
 # getters
@@ -39,6 +42,11 @@ def get_skyscan_cvmfs_singularity_image(tag: str) -> Path:
 def get_skyscan_docker_image(tag: str) -> str:
     """Get the docker image + tag for 'tag' (assumes it exists)."""
     return f"{_SKYSCAN_DOCKER_IMAGE_NO_TAG}:{tag}"
+
+
+def get_clientmanager_image() -> str:
+    """Get the clientmanager image + tag (assumes it exists)."""
+    return f"{_CLIENTMANAGER_IMAGE_NO_TAG}:{ENV.CLIENTMANAGER_IMAGE_TAG}"
 
 
 # ---------------------------------------------------------------------------------------

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -25,6 +25,9 @@ _SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH = Path(
 )
 VERSION_REGEX = re.compile(r"\d+\.\d+\.\d+")
 
+# clientmanager
+CLIENTMANAGER_IMAGE_WITH_TAG = "ghcr.io/wipacrepo/skydriver:latest"
+
 
 # ---------------------------------------------------------------------------------------
 # getters

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -34,9 +34,9 @@ CLIENTMANAGER_IMAGE_WITH_TAG = "ghcr.io/wipacrepo/skydriver:latest"
 # getters
 
 
-def get_skyscan_cvmfs_singularity_image(tag: str) -> str:
+def get_skyscan_cvmfs_singularity_image(tag: str) -> Path:
     """Get the singularity image path for 'tag' (assumes it exists)."""
-    return f"{_SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH}{_IMAGE}:{tag}"
+    return _SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH / f"{_IMAGE}:{tag}"
 
 
 def get_skyscan_docker_image(tag: str) -> str:

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 from typing import Iterator
 
+import cachetools.func
 import requests
 
 from .config import LOGGER
@@ -47,6 +48,7 @@ def get_skyscan_docker_image(tag: str) -> str:
 # utils
 
 
+@cachetools.func.ttl_cache(ttl=5 * 60)
 def resolve_latest() -> str:
     """Get the most recent version-tag on Docker Hub.
 

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -13,21 +13,35 @@ from .config import LOGGER
 
 
 _IMAGE = "skymap_scanner"
-SKYSCAN_DOCKER_IMAGE_NO_TAG = f"icecube/{_IMAGE}"
+_SKYSCAN_DOCKER_IMAGE_NO_TAG = f"icecube/{_IMAGE}"
 
-DOCKERHUB_API_URL = "https://hub.docker.com/v2/repositories/icecube/skymap_scanner/tags"
+DOCKERHUB_API_URL = (
+    f"https://hub.docker.com/v2/repositories/{_SKYSCAN_DOCKER_IMAGE_NO_TAG}/tags"
+)
 
 # cvmfs singularity
-SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH = Path(
+_SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH = Path(
     "/cvmfs/icecube.opensciencegrid.org/containers/realtime/"
 )
 VERSION_REGEX = re.compile(r"\d+\.\d+\.\d+")
 
 
 # ---------------------------------------------------------------------------------------
+# getters
+
+
+def get_skyscan_cvmfs_singularity_image(tag: str) -> str:
+    """Get the singularity image path for 'tag' (assumes it exists)."""
+    return f"{_SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH}{_IMAGE}:{tag}"
+
+
+def get_skyscan_docker_image(tag: str) -> str:
+    """Get the docker image + tag for 'tag' (assumes it exists)."""
+    return f"{_SKYSCAN_DOCKER_IMAGE_NO_TAG}:{tag}"
+
+
+# ---------------------------------------------------------------------------------------
 # utils
-
-
 def resolve_latest() -> str:
     """Get the most recent version-tag on Docker Hub.
 
@@ -59,7 +73,7 @@ def resolve_latest() -> str:
 
 def get_all_cvmfs_image_tags() -> Iterator[str]:
     """Get all the skymap scanner image tags in CVMFS."""
-    for fpath in SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH.iterdir():
+    for fpath in _SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH.iterdir():
         image, tag = fpath.name.split(":", maxsplit=1)  # ex: skymap_scannner:3.6.9
         if image == _IMAGE:
             yield tag

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -49,7 +49,7 @@ def get_skyscan_docker_image(tag: str) -> str:
 
 
 @cachetools.func.ttl_cache(ttl=5 * 60)
-def resolve_latest() -> str:
+def resolve_latest_docker_hub() -> str:
     """Get the most recent version-tag on Docker Hub.
 
     This is needed because 'latest' doesn't exist in CVMFS.
@@ -89,8 +89,11 @@ def get_all_cvmfs_image_tags() -> Iterator[str]:
 def resolve_docker_tag(docker_tag: str) -> str:
     """Check if the docker tag exists, then resolve 'latest' if needed."""
     if docker_tag == "latest":
-        docker_tag = resolve_latest()
-    elif docker_tag.startswith("v"):
+        # NOTE: assumes tag exists (or will soon) on CVMFS
+        #       condor will back off & retry until the image exists
+        return resolve_latest_docker_hub()
+
+    if docker_tag.startswith("v"):
         # v3.6.9 -> 3.6.9 (if needed)
         if VERSION_REGEX.fullmatch(without_v := docker_tag.lstrip("v")):
             docker_tag = without_v

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -81,7 +81,6 @@ def _try_resolve_to_majminpatch_docker_hub(docker_tag: str) -> str:
         while True:
             resp = requests.get(url).json()
             for img in resp["results"]:
-                LOGGER.debug(img)
                 if sha != img["digest"]:
                     continue
                 if VERSION_REGEX_MAJMINPATCH.fullmatch(img["name"]):

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -98,4 +98,4 @@ def resolve_docker_tag(docker_tag: str) -> str:
     # in CVMFS?
     if docker_tag in get_all_cvmfs_image_tags():
         return docker_tag
-    raise ValueError("Tag not in CVMFS")
+    raise ValueError(f"Tag not in CVMFS: {docker_tag}")

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -42,6 +42,8 @@ def get_skyscan_docker_image(tag: str) -> str:
 
 # ---------------------------------------------------------------------------------------
 # utils
+
+
 def resolve_latest() -> str:
     """Get the most recent version-tag on Docker Hub.
 

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -26,9 +26,6 @@ _SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH = Path(
 VERSION_REGEX_MAJMINPATCH = re.compile(r"\d+\.\d+\.\d+")
 VERSION_REGEX_PREFIX_V = re.compile(r"(v|V)\d+(\.\d+(\.\d+)?)?")
 
-# clientmanager
-CLIENTMANAGER_IMAGE = f"ghcr.io/wipacrepo/skydriver:{ENV.CLIENTMANAGER_IMAGE_TAG}"
-
 
 # ---------------------------------------------------------------------------------------
 # getters

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -80,11 +80,12 @@ def _try_resolve_to_majminpatch_docker_hub(docker_tag: str) -> str:
         url = DOCKERHUB_API_URL
         while True:
             resp = requests.get(url).json()
-            for img in resp["results"]:
-                if sha != img["digest"]:
+            for result in resp["results"]:
+                if sha != result.get("digest", result["images"][0]["digest"]):
+                    # some old ones have their 'digest' in their 'images' list entry
                     continue
-                if VERSION_REGEX_MAJMINPATCH.fullmatch(img["name"]):
-                    return img["name"]  # type: ignore[no-any-return]
+                if VERSION_REGEX_MAJMINPATCH.fullmatch(result["name"]):
+                    return result["name"]  # type: ignore[no-any-return]
             if not resp["next"]:
                 break
             url = resp["next"]

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -27,7 +27,7 @@ VERSION_REGEX_MAJMINPATCH = re.compile(r"\d+\.\d+\.\d+")
 VERSION_REGEX_PREFIX_V = re.compile(r"v\d+(\.\d+(\.\d+)?)?")
 
 # clientmanager
-_CLIENTMANAGER_IMAGE_NO_TAG = "ghcr.io/wipacrepo/skydriver"
+CLIENTMANAGER_IMAGE = f"ghcr.io/wipacrepo/skydriver:{ENV.CLIENTMANAGER_IMAGE_TAG}"
 
 
 # ---------------------------------------------------------------------------------------
@@ -42,11 +42,6 @@ def get_skyscan_cvmfs_singularity_image(tag: str) -> Path:
 def get_skyscan_docker_image(tag: str) -> str:
     """Get the docker image + tag for 'tag' (assumes it exists)."""
     return f"{_SKYSCAN_DOCKER_IMAGE_NO_TAG}:{tag}"
-
-
-def get_clientmanager_image() -> str:
-    """Get the clientmanager image + tag (assumes it exists)."""
-    return f"{_CLIENTMANAGER_IMAGE_NO_TAG}:{ENV.CLIENTMANAGER_IMAGE_TAG}"
 
 
 # ---------------------------------------------------------------------------------------

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -24,7 +24,7 @@ _SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH = Path(
     "/cvmfs/icecube.opensciencegrid.org/containers/realtime/"
 )
 VERSION_REGEX_MAJMINPATCH = re.compile(r"\d+\.\d+\.\d+")
-VERSION_REGEX_PREFIX_V = re.compile(r"v\d+(\.\d+(\.\d+)?)?")
+VERSION_REGEX_PREFIX_V = re.compile(r"(v|V)\d+(\.\d+(\.\d+)?)?")
 
 # clientmanager
 CLIENTMANAGER_IMAGE = f"ghcr.io/wipacrepo/skydriver:{ENV.CLIENTMANAGER_IMAGE_TAG}"

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -78,7 +78,7 @@ def _try_resolve_to_majminpatch_docker_hub(docker_tag: str) -> str:
         No error handling
         """
         url = DOCKERHUB_API_URL
-        while url:
+        while True:
             resp = requests.get(url).json()
             for img in resp["results"]:
                 LOGGER.debug(img)
@@ -111,6 +111,8 @@ def _try_resolve_to_majminpatch_docker_hub(docker_tag: str) -> str:
 
 def tag_exists_on_docker_hub(docker_tag: str) -> bool:
     """Return whether the tag exists on Docker Hub."""
+    if not docker_tag or not docker_tag.strip():
+        return False
     try:
         return requests.get(f"{DOCKERHUB_API_URL}/{docker_tag}").ok
     except Exception as e:

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -81,6 +81,7 @@ def _try_resolve_to_majminpatch_docker_hub(docker_tag: str) -> str:
         while url:
             resp = requests.get(url).json()
             for img in resp["results"]:
+                LOGGER.debug(img)
                 if sha != img["digest"]:
                     continue
                 if VERSION_REGEX_MAJMINPATCH.fullmatch(img["name"]):

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import cachetools.func
 import requests
 
-from .config import LOGGER
+from .config import ENV, LOGGER
 
 # ---------------------------------------------------------------------------------------
 # constants
@@ -25,9 +25,6 @@ _SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH = Path(
 )
 VERSION_REGEX_MAJMINPATCH = re.compile(r"\d+\.\d+\.\d+")
 VERSION_REGEX_PREFIX_V = re.compile(r"v\d+(\.\d+(\.\d+)?)?")
-
-# clientmanager
-CLIENTMANAGER_IMAGE_WITH_TAG = "ghcr.io/wipacrepo/skydriver:latest"
 
 
 # ---------------------------------------------------------------------------------------

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -88,6 +88,9 @@ def get_all_cvmfs_image_tags() -> Iterator[str]:
 
 def resolve_docker_tag(docker_tag: str) -> str:
     """Check if the docker tag exists, then resolve 'latest' if needed."""
+    if not docker_tag:
+        raise ValueError("Invalid docker tag")
+
     if docker_tag == "latest":
         # NOTE: assumes tag exists (or will soon) on CVMFS
         #       condor will back off & retry until the image exists

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -97,10 +97,9 @@ def resolve_docker_tag(docker_tag: str) -> str:
     if docker_tag == "latest":  # 'latest' doesn't exist in CVMFS
         return pseudonym_to_full_version_docker_hub("latest")
 
-    if docker_tag.startswith("v"):
+    if VERSION_REGEX_PREFIX_V.fullmatch(docker_tag):
         # v4 -> 4; v5.1 -> 5.1; v3.6.9 -> 3.6.9
-        if VERSION_REGEX_PREFIX_V.fullmatch(docker_tag):
-            docker_tag = docker_tag.lstrip("v")
+        docker_tag = docker_tag.lstrip("v")
 
     if not tag_exists_on_docker_hub(docker_tag):
         raise ValueError(f"Image tag not on Docker Hub: {docker_tag}")

--- a/skydriver/images.py
+++ b/skydriver/images.py
@@ -1,0 +1,66 @@
+"""Utilities for dealing with docker/cvmfs/singularity images."""
+
+import re
+from pathlib import Path
+from typing import Iterator
+
+import requests
+
+_IMAGE = "skymap_scanner"
+SKYSCAN_DOCKER_IMAGE_NO_TAG = f"icecube/{_IMAGE}"
+
+DOCKERHUB_API_URL = "https://hub.docker.com/v2/repositories/icecube/skymap_scanner/tags"
+
+# cvmfs singularity
+SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH = Path(
+    "/cvmfs/icecube.opensciencegrid.org/containers/realtime/"
+)
+VERSION_REGEX = re.compile(r"\d+\.\d+\.\d+")
+
+
+def resolve_latest() -> str:
+    """Get the most recent version-tag on Docker Hub.
+
+    This is needed because 'latest' doesn't exist in CVMFS.
+    """
+    # gives 10 most recent tags by default
+    images = requests.get(DOCKERHUB_API_URL).json()["results"]
+
+    def latest_sha() -> str:
+        for img in images:
+            if img["name"] == "latest":
+                return img["digest"]  # type: ignore[no-any-return]
+        raise RuntimeError("Image tag 'latest' not found on Docker Hub")
+
+    def matching_sha(sha: str) -> Iterator[str]:
+        for img in images:
+            if img["digest"] == sha:
+                yield img["name"]
+
+    for tag in matching_sha(latest_sha()):
+        if VERSION_REGEX.fullmatch(tag):
+            return tag
+    raise RuntimeError("Image tag 'latest' could not resolve to a version")
+
+
+def get_all_cvmfs_image_tags() -> Iterator[str]:
+    """Get all the skymap scanner image tags in CVMFS."""
+    for fpath in SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH.iterdir():
+        image, tag = fpath.name.split(":", maxsplit=1)  # ex: skymap_scannner:3.6.9
+        if image == _IMAGE:
+            yield tag
+
+
+def resolve_docker_tag(docker_tag: str) -> str:
+    """Check if the docker tag exists, then resolve 'latest' if needed."""
+    if docker_tag == "latest":
+        docker_tag = resolve_latest()
+    elif docker_tag.startswith("v"):
+        # v3.6.9 -> 3.6.9 (if needed)
+        if VERSION_REGEX.fullmatch(without_v := docker_tag.lstrip("v")):
+            docker_tag = without_v
+
+    # in CVMFS?
+    if docker_tag in get_all_cvmfs_image_tags():
+        return docker_tag
+    raise Exception("Tag not in CVMFS")

--- a/skydriver/k8s.py
+++ b/skydriver/k8s.py
@@ -249,7 +249,7 @@ class SkymapScannerJob:
     @staticmethod
     def get_clientmanager_args(
         common_space_volume_path: Path,
-        singularity_image: str,
+        singularity_image: Path,
         njobs: int,
         memory: str,
         collector: str,

--- a/skydriver/k8s.py
+++ b/skydriver/k8s.py
@@ -213,7 +213,7 @@ class SkymapScannerJob:
         )
         condor_clientmanager = KubeAPITools.create_container(
             f"clientmanager-{scan_id}",
-            images.CLIENTMANAGER_IMAGE_WITH_TAG,
+            f"ghcr.io/wipacrepo/skydriver:{ENV.CLIENTMANAGER_IMAGE_TAG}",
             env,
             self.clientmanager_args.split(),
             {common_space_volume_path.name: common_space_volume_path},

--- a/skydriver/k8s.py
+++ b/skydriver/k8s.py
@@ -213,7 +213,7 @@ class SkymapScannerJob:
         )
         condor_clientmanager = KubeAPITools.create_container(
             f"clientmanager-{scan_id}",
-            f"ghcr.io/wipacrepo/skydriver:{ENV.CLIENTMANAGER_IMAGE_TAG}",
+            images.CLIENTMANAGER_IMAGE,
             env,
             self.clientmanager_args.split(),
             {common_space_volume_path.name: common_space_volume_path},

--- a/skydriver/k8s.py
+++ b/skydriver/k8s.py
@@ -213,7 +213,7 @@ class SkymapScannerJob:
         )
         condor_clientmanager = KubeAPITools.create_container(
             f"clientmanager-{scan_id}",
-            ENV.CLIENTMANAGER_IMAGE_WITH_TAG,
+            images.CLIENTMANAGER_IMAGE_WITH_TAG,
             env,
             self.clientmanager_args.split(),
             {common_space_volume_path.name: common_space_volume_path},

--- a/skydriver/k8s.py
+++ b/skydriver/k8s.py
@@ -8,6 +8,7 @@ import kubernetes.client  # type: ignore[import]
 from kubernetes.client.rest import ApiException  # type: ignore[import]
 from rest_tools.client import ClientCredentialsAuth
 
+from . import images
 from .config import ENV, LOGGER
 from .database import schema
 
@@ -188,7 +189,7 @@ class SkymapScannerJob:
         )
         self.clientmanager_args = self.get_clientmanager_args(
             common_space_volume_path=common_space_volume_path,
-            singularity_image=f"{ENV.SKYSCAN_SINGULARITY_IMAGE_PATH_NO_TAG}:{docker_tag}",
+            singularity_image=images.get_skyscan_cvmfs_singularity_image(docker_tag),
             njobs=njobs,
             memory=memory,
             collector=collector,
@@ -205,7 +206,7 @@ class SkymapScannerJob:
         # job
         server = KubeAPITools.create_container(
             f"server-{scan_id}",
-            f"{ENV.SKYSCAN_DOCKER_IMAGE_NO_TAG}:{docker_tag}",
+            images.get_skyscan_docker_image(docker_tag),
             env,
             self.server_args.split(),
             {common_space_volume_path.name: common_space_volume_path},

--- a/skydriver/k8s.py
+++ b/skydriver/k8s.py
@@ -213,7 +213,7 @@ class SkymapScannerJob:
         )
         condor_clientmanager = KubeAPITools.create_container(
             f"clientmanager-{scan_id}",
-            images.CLIENTMANAGER_IMAGE,
+            ENV.CLIENTMANAGER_IMAGE_WITH_TAG,
             env,
             self.clientmanager_args.split(),
             {common_space_volume_path.name: common_space_volume_path},

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -13,7 +13,7 @@ from motor.motor_asyncio import AsyncIOMotorClient  # type: ignore[import]
 from rest_tools.server import RestHandler, token_attribute_role_mapping_auth
 from tornado import web
 
-from . import database, k8s
+from . import database, images, k8s
 from .config import LOGGER, is_testing
 
 # -----------------------------------------------------------------------------
@@ -157,7 +157,7 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
         # docker args
         docker_tag = self.get_argument(
             "docker_tag",
-            type=str,
+            type=images.resolve_docker_tag,
             forbiddens=[r"\s*"],  # no empty string / whitespace
             default="latest",
         )

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -155,7 +155,7 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
             raise error
 
         # docker args
-        docker_tag = self.get_argument(
+        docker_tag = self.get_argument(  # either docker tag or 'latest'
             "docker_tag",
             type=images.resolve_docker_tag,
             forbiddens=[r"\s*"],  # no empty string / whitespace

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -155,7 +155,7 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
             raise error
 
         # docker args
-        docker_tag = self.get_argument(  # either docker tag or 'latest'
+        docker_tag = self.get_argument(  # any tag on docker hub (including 'latest') -- must also be on CVMFS (but not checked here)
             "docker_tag",
             type=images.resolve_docker_tag,
             forbiddens=[r"\s*"],  # no empty string / whitespace

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -159,7 +159,6 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
             "docker_tag",
             type=images.resolve_docker_tag,
             forbiddens=[r"\s*"],  # no empty string / whitespace
-            default="latest",
         )
 
         # condor args

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -455,7 +455,7 @@ async def _delete_result(
 ########################################################################################
 
 
-@pytest.mark.parametrize("docker_tag", ["latest", "3.4.2"])
+@pytest.mark.parametrize("docker_tag", ["latest", "3.4.0"])
 async def test_00(docker_tag: str, server: Callable[[], RestClient]) -> None:
     """Test normal scan creation and retrieval."""
     rc = server()

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -84,6 +84,7 @@ POST_SCAN_BODY = {
     "event_i3live_json": {"a": 22},
     "nsides": {1: 2, 3: 4},
     "real_or_simulated_event": "real",
+    "docker_tag": "latest",
 }
 
 

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -455,7 +455,7 @@ async def _delete_result(
 ########################################################################################
 
 
-@pytest.mark.parametrize("docker_tag", ["latest", "3.0.74"])
+@pytest.mark.parametrize("docker_tag", ["latest", "3.4.2"])
 async def test_00(docker_tag: str, server: Callable[[], RestClient]) -> None:
     """Test normal scan creation and retrieval."""
     rc = server()

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -112,7 +112,7 @@ async def _launch_scan(rc: RestClient, post_scan_body: dict) -> str:
         f" --logs-directory /common-space "
         f" --jobs {post_scan_body['njobs']} "
         f" --memory {post_scan_body['memory']} "
-        # rely on _SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH mocking & CI env var
+        # rely on CI env var
         f" --singularity-image {skydriver.images._SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH/'skymap_scanner'}:{tag} "
         f" --client-startup-json /common-space/startup.json "
     )
@@ -456,10 +456,6 @@ async def _delete_result(
 ########################################################################################
 
 
-@patch(
-    "skydriver.images._SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH",
-    Path("tests/resources/mock-cvmfs-images"),
-)
 @pytest.mark.parametrize("docker_tag", ["latest", "3.0.74"])
 async def test_00(docker_tag: str, server: Callable[[], RestClient]) -> None:
     """Test normal scan creation and retrieval."""
@@ -505,10 +501,6 @@ async def test_00(docker_tag: str, server: Callable[[], RestClient]) -> None:
     await _delete_result(rc, scan_id, result, True)
 
 
-@patch(
-    "skydriver.images._SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH",
-    Path("tests/resources/mock-cvmfs-images"),
-)
 async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     """Failure-test scan creation and retrieval."""
     rc = server()

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -106,7 +106,8 @@ async def _launch_scan(rc: RestClient) -> str:
         f" --logs-directory /common-space "
         f" --jobs {POST_SCAN_BODY['njobs']} "
         f" --memory {POST_SCAN_BODY['memory']} "
-        f" --singularity-image /cvmfs/icecube.opensciencegrid.org/containers/realtime/skymap_scanner:{os.getenv('LATEST_TAG')} "
+        # rely on _SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH mocking & CI env var
+        f" --singularity-image {skydriver.images._SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH/'skymap_scanner'}:{os.getenv('LATEST_TAG')} "
         f" --client-startup-json /common-space/startup.json "
     )
 

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -450,7 +450,7 @@ async def _delete_result(
 
 
 @pytest.mark.parametrize(
-    "docker_tag_inout",
+    "docker_tag_input_and_expect",
     [
         ("latest", os.environ["LATEST_TAG"]),
         ("3.4.0", "3.4.0"),

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -6,7 +6,6 @@ import os
 import random
 import re
 import socket
-from pathlib import Path
 from typing import Any, AsyncIterator, Callable
 from unittest.mock import Mock, patch
 

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -11,7 +11,7 @@ from unittest.mock import Mock, patch
 import pytest
 import pytest_asyncio
 import requests
-import skydriver.images
+import skydriver.images  # noqa: F401
 from motor.motor_asyncio import AsyncIOMotorClient  # type: ignore
 from rest_tools.client import RestClient
 from skydriver.config import config_logging

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -5,6 +5,7 @@
 import random
 import re
 import socket
+from pathlib import Path
 from typing import Any, AsyncIterator, Callable
 from unittest.mock import Mock, patch
 
@@ -449,7 +450,7 @@ async def _delete_result(
 
 @patch(
     "skydriver.images._SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH",
-    "tests/resources/mock-cvmfs-images",
+    Path("tests/resources/mock-cvmfs-images"),
 )
 async def test_00(server: Callable[[], RestClient]) -> None:
     """Test normal scan creation and retrieval."""
@@ -497,7 +498,7 @@ async def test_00(server: Callable[[], RestClient]) -> None:
 
 @patch(
     "skydriver.images._SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH",
-    "tests/resources/mock-cvmfs-images",
+    Path("tests/resources/mock-cvmfs-images"),
 )
 async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     """Failure-test scan creation and retrieval."""

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -552,6 +552,13 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
                 "POST", "/scan", {k: v for k, v in POST_SCAN_BODY.items() if k != arg}
             )
         print(e.value)
+    # # bad docker tag
+    with pytest.raises(
+        requests.exceptions.HTTPError,
+        match=rf"400 Client Error: `docker_tag`: \(ValueError\) .+ for url: {rc.address}/scan",
+    ) as e:
+        await rc.request("POST", "/scan", {**POST_SCAN_BODY, "docker_tag": "foo"})
+    print(e.value)
 
     # OK
     scan_id = await _launch_scan(rc)

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=redefined-outer-name
 
+import os
 import random
 import re
 import socket
@@ -105,7 +106,7 @@ async def _launch_scan(rc: RestClient) -> str:
         f" --logs-directory /common-space "
         f" --jobs {POST_SCAN_BODY['njobs']} "
         f" --memory {POST_SCAN_BODY['memory']} "
-        f" --singularity-image /cvmfs/icecube.opensciencegrid.org/containers/realtime/skymap_scanner:latest "
+        f" --singularity-image /cvmfs/icecube.opensciencegrid.org/containers/realtime/skymap_scanner:{os.getenv('LATEST_TAG')} "
         f" --client-startup-json /common-space/startup.json "
     )
 

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -66,7 +66,7 @@ async def server(
     rs.startup(address="localhost", port=port)  # type: ignore[no-untyped-call]
 
     def client() -> RestClient:
-        return RestClient(f"http://localhost:{port}", timeout=1, retries=0)
+        return RestClient(f"http://localhost:{port}", retries=0)
 
     try:
         yield client

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 import pytest
 import pytest_asyncio
 import requests
+import skydriver.images
 from motor.motor_asyncio import AsyncIOMotorClient  # type: ignore
 from rest_tools.client import RestClient
 from skydriver.config import config_logging
@@ -446,6 +447,10 @@ async def _delete_result(
 ########################################################################################
 
 
+@patch(
+    "skydriver.images._SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH",
+    "tests/resources/mock-cvmfs-images",
+)
 async def test_00(server: Callable[[], RestClient]) -> None:
     """Test normal scan creation and retrieval."""
     rc = server()
@@ -490,6 +495,10 @@ async def test_00(server: Callable[[], RestClient]) -> None:
     await _delete_result(rc, scan_id, result, True)
 
 
+@patch(
+    "skydriver.images._SKYSCAN_CVMFS_SINGULARITY_IMAGES_DPATH",
+    "tests/resources/mock-cvmfs-images",
+)
 async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     """Failure-test scan creation and retrieval."""
     rc = server()


### PR DESCRIPTION
- Resolves `latest` to the actual version tag by matching SHA values using Docker Hub's API
	* This occurs immediately on reading input and the matching version tag is used at every step thereafter
	* Resolution is needed because there is no `latest` tag in CVMFS's images
	* Doing this logic at the top of the pipeline guarantees all containers in a scanner instance are using the same version (the same `latest`) by removing race conditions
- Checks if the requestor-provided docker tag is on Docker Hub before launching the scanner
	* Assumes tag exists (or will soon) on CVMFS. Condor will back off & retry until the image exists
- Makes the `docker_tag` argument mandatory
- Adds support for "shorthand versions", like `3.4` and `3`. These are resolved like `latest`.
- "Branch docker tags" will continue to be supported