### PR TITLE
Add `/scan/SCANID` + Route Refactors

### DIFF
--- a/requirements-clientmanager.txt
+++ b/requirements-clientmanager.txt
@@ -28,7 +28,7 @@ coloredlogs==15.0.1
     # via
     #   UNKNOWN (setup.py)
     #   wipac-telemetry
-cryptography==40.0.1
+cryptography==40.0.2
     # via pyjwt
 dacite==1.8.0
     # via UNKNOWN (setup.py)

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -22,7 +22,7 @@ coloredlogs==15.0.1
     # via
     #   UNKNOWN (setup.py)
     #   wipac-telemetry
-cryptography==40.0.1
+cryptography==40.0.2
     # via pyjwt
 dacite==1.8.0
     # via UNKNOWN (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ coloredlogs==15.0.1
     # via
     #   UNKNOWN (setup.py)
     #   wipac-telemetry
-cryptography==40.0.1
+cryptography==40.0.2
     # via pyjwt
 dacite==1.8.0
     # via UNKNOWN (setup.py)

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -360,6 +360,21 @@ class ScanHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
             }
         )
 
+    @service_account_auth(roles=[USER_ACCT, SKYMAP_SCANNER_ACCT])  # type: ignore
+    async def get(self, scan_id: str) -> None:
+        """Get manifest & result."""
+        incl_del = self.get_argument("include_deleted", default=False, type=bool)
+
+        manifest = await self.manifests.get(scan_id, incl_del)
+        result = await self.results.get(scan_id, incl_del)
+
+        self.write(
+            {
+                "manifest": dc.asdict(manifest),
+                "result": dc.asdict(result),
+            }
+        )
+
 
 # -----------------------------------------------------------------------------
 

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -379,7 +379,7 @@ class ScanHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
 # -----------------------------------------------------------------------------
 
 
-class ManifestHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
+class ScanManifestHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
     """Handles actions on scan's manifest."""
 
     ROUTE = r"/scan/(?P<scan_id>\w+)/manifest$"
@@ -442,7 +442,7 @@ class ManifestHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
 # -----------------------------------------------------------------------------
 
 
-class ResultsHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
+class ScanResultHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
     """Handles actions on persisted scan results."""
 
     ROUTE = r"/scan/(?P<scan_id>\w+)/result$"

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -333,7 +333,7 @@ class ScanHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
         # check DB states
         manifest = await self.manifests.get(scan_id, True)
         if manifest.complete and not delete_completed_scan:
-            msg = "Attempting to delete a completed scan. Use `delete_completed_scan=True`."
+            msg = "Attempted to delete a completed scan (must use `delete_completed_scan=True`)"
             raise web.HTTPError(
                 400,
                 log_message=msg,

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -382,7 +382,7 @@ class ScanHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
 class ManifestHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
     """Handles actions on scan's manifest."""
 
-    ROUTE = r"/scan/manifest/(?P<scan_id>\w+)$"
+    ROUTE = r"/scan/(?P<scan_id>\w+)/manifest$"
 
     @service_account_auth(roles=[USER_ACCT, SKYMAP_SCANNER_ACCT])  # type: ignore
     async def get(self, scan_id: str) -> None:
@@ -445,7 +445,7 @@ class ManifestHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
 class ResultsHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
     """Handles actions on persisted scan results."""
 
-    ROUTE = r"/scan/result/(?P<scan_id>\w+)$"
+    ROUTE = r"/scan/(?P<scan_id>\w+)/result$"
 
     @service_account_auth(roles=[USER_ACCT])  # type: ignore
     async def get(self, scan_id: str) -> None:

--- a/skydriver/server.py
+++ b/skydriver/server.py
@@ -85,8 +85,9 @@ async def make(debug: bool = False) -> RestServer:
     for klass in [
         rest_handlers.RunEventMappingHandler,
         rest_handlers.MainHandler,
-        rest_handlers.ManifestHandler,
-        rest_handlers.ResultsHandler,
+        rest_handlers.ScanHandler,
+        rest_handlers.ScanManifestHandler,
+        rest_handlers.ScanResultHandler,
         rest_handlers.ScanLauncherHandler,
     ]:
         try:

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -775,7 +775,7 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     #
 
     # ERROR
-    # # try to deleted completed scan
+    # # try to delete completed scan
     with pytest.raises(
         requests.exceptions.HTTPError,
         match=re.escape(
@@ -796,7 +796,7 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     print(e.value)
 
     # OK
-    await _delete_scan(rc, event_metadata, scan_id, manifest, result, False, True)
+    await _delete_scan(rc, event_metadata, scan_id, manifest, result, True, True)
 
     # also OK
-    await _delete_scan(rc, event_metadata, scan_id, manifest, result, False, True)
+    await _delete_scan(rc, event_metadata, scan_id, manifest, result, True, True)

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -695,15 +695,6 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     #
 
     # ERROR - update PROGRESS
-    # # no arg
-    with pytest.raises(
-        requests.exceptions.HTTPError,
-        match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/manifest"
-        ),
-    ) as e:
-        await rc.request("PATCH", f"/scan/{scan_id}/manifest")
-    print(e.value)
     # # no arg w/ body
     with pytest.raises(
         requests.exceptions.HTTPError,
@@ -745,30 +736,11 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     ) as e:
         await _do_patch(rc, scan_id, scan_metadata={"boo": "baz", "bot": "fox"})
 
-    # # no arg
-    with pytest.raises(
-        requests.exceptions.HTTPError,
-        match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/manifest"
-        ),
-    ) as e:
-        await rc.request("GET", f"/scan/{scan_id}/manifest")
-    print(e.value)
-
     #
     # SEND RESULT
     #
 
     # ERROR
-    # # no arg
-    with pytest.raises(
-        requests.exceptions.HTTPError,
-        match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/result"
-        ),
-    ) as e:
-        await rc.request("PUT", f"/scan/{scan_id}/result")
-    print(e.value)
     # # no arg w/ body
     with pytest.raises(
         requests.exceptions.HTTPError,
@@ -817,27 +789,29 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     manifest = await rc.request("GET", f"/scan/{scan_id}/manifest")
     assert manifest["complete"]
 
-    # # no arg
-    with pytest.raises(
-        requests.exceptions.HTTPError,
-        match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/result"
-        ),
-    ) as e:
-        await rc.request("GET", f"/scan/{scan_id}/result")
-    print(e.value)
-
     #
     # DELETE SCAN
     #
 
     # ERROR
-    # # no arg
+    # # try to deleted completed scan
     with pytest.raises(
         requests.exceptions.HTTPError,
-        match=re.escape(f"404 Client Error: Not Found for url: {rc.address}/scan"),
+        match=re.escape(
+            f"400 Client Error: Attempted to delete a completed scan "
+            f"(must use `delete_completed_scan=True`) for url: {rc.address}/scan"
+        ),
     ) as e:
-        await rc.request("DELETE", "/scan")
+        await rc.request("DELETE", f"/scan/{scan_id}", {"delete_completed_scan": False})
+    print(e.value)
+    with pytest.raises(
+        requests.exceptions.HTTPError,
+        match=re.escape(
+            f"400 Client Error: Attempted to delete a completed scan "
+            f"(must use `delete_completed_scan=True`) for url: {rc.address}/scan"
+        ),
+    ) as e:
+        await rc.request("DELETE", f"/scan/{scan_id}")
     print(e.value)
 
     # OK

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -231,7 +231,7 @@ async def _do_patch(
     condor_cluster: StrDict | None = None,
     previous_clusters: list[StrDict] | None = None,
 ) -> StrDict:
-    # do PATCH @ /scan/manifest, assert response
+    # do PATCH @ /scan/{scan_id}/manifest, assert response
     body = {}
     if progress:
         body["progress"] = progress
@@ -675,7 +675,7 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     with pytest.raises(
         requests.exceptions.HTTPError,
         match=re.escape(
-            f"400 Client Error: Cannot change an existing event_metadata for url: {rc.address}/scan/manifest"
+            f"400 Client Error: Cannot change an existing event_metadata for url: {rc.address}/scan/{scan_id}/manifest"
         ),
     ) as e:
         await _do_patch(
@@ -699,19 +699,19 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     with pytest.raises(
         requests.exceptions.HTTPError,
         match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/manifest"
+            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/manifest"
         ),
     ) as e:
-        await rc.request("PATCH", "/scan/manifest")
+        await rc.request("PATCH", f"/scan/{scan_id}/manifest")
     print(e.value)
     # # no arg w/ body
     with pytest.raises(
         requests.exceptions.HTTPError,
         match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/manifest"
+            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/manifest"
         ),
     ) as e:
-        await rc.request("PATCH", "/scan/manifest", {"progress": {"a": 1}})
+        await rc.request("PATCH", f"/scan/{scan_id}/manifest", {"progress": {"a": 1}})
     print(e.value)
     # # empty body-arg -- this is okay, it'll silently do nothing
     # with pytest.raises(
@@ -740,7 +740,7 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     with pytest.raises(
         requests.exceptions.HTTPError,
         match=re.escape(
-            f"400 Client Error: Cannot change an existing scan_metadata for url: {rc.address}/scan/manifest"
+            f"400 Client Error: Cannot change an existing scan_metadata for url: {rc.address}/scan/{scan_id}/manifest"
         ),
     ) as e:
         await _do_patch(rc, scan_id, scan_metadata={"boo": "baz", "bot": "fox"})
@@ -749,10 +749,10 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     with pytest.raises(
         requests.exceptions.HTTPError,
         match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/manifest"
+            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/manifest"
         ),
     ) as e:
-        await rc.request("GET", "/scan/manifest")
+        await rc.request("GET", f"/scan/{scan_id}/manifest")
     print(e.value)
 
     #
@@ -764,19 +764,21 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     with pytest.raises(
         requests.exceptions.HTTPError,
         match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/result"
+            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/result"
         ),
     ) as e:
-        await rc.request("PUT", "/scan/result")
+        await rc.request("PUT", f"/scan/{scan_id}/result")
     print(e.value)
     # # no arg w/ body
     with pytest.raises(
         requests.exceptions.HTTPError,
         match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/result"
+            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/result"
         ),
     ) as e:
-        await rc.request("PUT", "/scan/result", {"skyscan_result": {"bb": 22}})
+        await rc.request(
+            "PUT", f"/scan/{scan_id}/result", {"skyscan_result": {"bb": 22}}
+        )
     print(e.value)
     # # empty body
     with pytest.raises(
@@ -819,10 +821,10 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     with pytest.raises(
         requests.exceptions.HTTPError,
         match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/result"
+            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/result"
         ),
     ) as e:
-        await rc.request("GET", "/scan/result")
+        await rc.request("GET", f"/scan/{scan_id}/result")
     print(e.value)
 
     #

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -417,16 +417,11 @@ async def _delete_scan(
     resp = await rc.request("DELETE", f"/scan/{scan_id}", body)
     assert resp == {
         "manifest": dict(
+            **resp["manifest"],
+            # only checking these fields:
             scan_id=scan_id,
             is_deleted=True,
-            event_metadata=resp["event_metadata"],
             progress=last_known_manifest["progress"],
-            event_i3live_json_dict=resp["event_i3live_json_dict"],  # not checking
-            scan_metadata=resp["scan_metadata"],  # not checking
-            condor_clusters=resp["condor_clusters"],  # not checking
-            scanner_server_args=resp["scanner_server_args"],  # not checking
-            tms_args=resp["tms_args"],  # not checking
-            env_vars=resp["env_vars"],  # not checking
             complete=last_known_manifest["complete"],
             # TODO: check more fields in future (hint: ctrl+F this comment)
         ),

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -411,7 +411,10 @@ async def _delete_scan(
     is_final: bool,
 ) -> None:
     # DELETE SCAN
-    resp = await rc.request("DELETE", f"/scan/{scan_id}")
+    body = {}
+    if is_final:
+        body["delete_completed_scan"] = True
+    resp = await rc.request("DELETE", f"/scan/{scan_id}", body)
     assert resp == {
         "manifest": dict(
             scan_id=scan_id,

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -695,15 +695,6 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     #
 
     # ERROR - update PROGRESS
-    # # no arg w/ body
-    with pytest.raises(
-        requests.exceptions.HTTPError,
-        match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/manifest"
-        ),
-    ) as e:
-        await rc.request("PATCH", f"/scan/{scan_id}/manifest", {"progress": {"a": 1}})
-    print(e.value)
     # # empty body-arg -- this is okay, it'll silently do nothing
     # with pytest.raises(
     #     requests.exceptions.HTTPError,
@@ -741,17 +732,6 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     #
 
     # ERROR
-    # # no arg w/ body
-    with pytest.raises(
-        requests.exceptions.HTTPError,
-        match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/result"
-        ),
-    ) as e:
-        await rc.request(
-            "PUT", f"/scan/{scan_id}/result", {"skyscan_result": {"bb": 22}}
-        )
-    print(e.value)
     # # empty body
     with pytest.raises(
         requests.exceptions.HTTPError,

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -244,7 +244,7 @@ async def _do_patch(
         assert isinstance(previous_clusters, list)  # gotta include this one too
     assert body
 
-    resp = await rc.request("PATCH", f"/scan/manifest/{scan_id}", body)
+    resp = await rc.request("PATCH", f"/scan/{scan_id}/manifest", body)
     assert resp == dict(
         scan_id=scan_id,
         is_deleted=False,
@@ -277,7 +277,7 @@ async def _do_patch(
     )
     manifest = resp  # keep around
     # query progress
-    resp = await rc.request("GET", f"/scan/manifest/{scan_id}")
+    resp = await rc.request("GET", f"/scan/{scan_id}/manifest")
     assert resp == manifest
     return manifest  # type: ignore[no-any-return]
 
@@ -380,7 +380,7 @@ async def _send_result(
         result["gamma"] = 5
     resp = await rc.request(
         "PUT",
-        f"/scan/result/{scan_id}",
+        f"/scan/{scan_id}/result",
         {"skyscan_result": result, "is_final": is_final},
     )
     assert resp == {
@@ -392,55 +392,91 @@ async def _send_result(
     result = resp  # keep around
 
     # query progress
-    resp = await rc.request("GET", f"/scan/manifest/{scan_id}")
+    resp = await rc.request("GET", f"/scan/{scan_id}/manifest")
     assert resp == last_known_manifest
 
     # query result
-    resp = await rc.request("GET", f"/scan/result/{scan_id}")
+    resp = await rc.request("GET", f"/scan/{scan_id}/result")
     assert resp == result
 
     return result
 
 
-async def _delete_manifest(
+async def _delete_scan(
     rc: RestClient,
     event_metadata: StrDict,
     scan_id: str,
     last_known_manifest: StrDict,
     last_known_result: StrDict,
+    is_final: bool,
 ) -> None:
-    # delete manifest
-    resp = await rc.request("DELETE", f"/scan/manifest/{scan_id}")
-    assert resp == dict(
-        scan_id=scan_id,
-        is_deleted=True,
-        event_metadata=resp["event_metadata"],
-        progress=last_known_manifest["progress"],
-        event_i3live_json_dict=resp["event_i3live_json_dict"],  # not checking
-        scan_metadata=resp["scan_metadata"],  # not checking
-        condor_clusters=resp["condor_clusters"],  # not checking
-        scanner_server_args=resp["scanner_server_args"],  # not checking
-        tms_args=resp["tms_args"],  # not checking
-        env_vars=resp["env_vars"],  # not checking
-        complete=last_known_manifest["complete"],
-        # TODO: check more fields in future (hint: ctrl+F this comment)
-    )
+    # DELETE SCAN
+    resp = await rc.request("DELETE", f"/scan/{scan_id}")
+    assert resp == {
+        "manifest": dict(
+            scan_id=scan_id,
+            is_deleted=True,
+            event_metadata=resp["event_metadata"],
+            progress=last_known_manifest["progress"],
+            event_i3live_json_dict=resp["event_i3live_json_dict"],  # not checking
+            scan_metadata=resp["scan_metadata"],  # not checking
+            condor_clusters=resp["condor_clusters"],  # not checking
+            scanner_server_args=resp["scanner_server_args"],  # not checking
+            tms_args=resp["tms_args"],  # not checking
+            env_vars=resp["env_vars"],  # not checking
+            complete=last_known_manifest["complete"],
+            # TODO: check more fields in future (hint: ctrl+F this comment)
+        ),
+        "result": {
+            "scan_id": scan_id,
+            "is_deleted": True,
+            "is_final": is_final,
+            "skyscan_result": last_known_result["skyscan_result"],
+        },
+    }
     del_resp = resp  # keep around
 
-    # query w/ scan id (fails)
+    #
+
+    # SCAN: query w/ scan id (fails)
     with pytest.raises(
         requests.exceptions.HTTPError,
         match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/manifest/{scan_id}"
+            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}"
         ),
     ):
-        await rc.request("GET", f"/scan/manifest/{scan_id}")
+        await rc.request("GET", f"/scan/{scan_id}")
+    # query w/ incl_del
+    resp = await rc.request("GET", f"/scan/{scan_id}", {"include_deleted": True})
+    assert resp == del_resp
 
+    # MANIFEST: query w/ scan id (fails)
+    with pytest.raises(
+        requests.exceptions.HTTPError,
+        match=re.escape(
+            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/manifest"
+        ),
+    ):
+        await rc.request("GET", f"/scan/{scan_id}/manifest")
     # query w/ incl_del
     resp = await rc.request(
-        "GET", f"/scan/manifest/{scan_id}", {"include_deleted": True}
+        "GET", f"/scan/{scan_id}/manifest", {"include_deleted": True}
     )
-    assert resp == del_resp
+    assert resp == del_resp["manifest"]
+
+    # RESULT: query w/ scan id (fails)
+    with pytest.raises(
+        requests.exceptions.HTTPError,
+        match=re.escape(
+            f"404 Client Error: Not Found for url: {rc.address}/scan/{scan_id}/result"
+        ),
+    ):
+        await rc.request("GET", f"/scan/{scan_id}/result")
+    # query w/ incl_del
+    resp = await rc.request("GET", f"/scan/{scan_id}/result", {"include_deleted": True})
+    assert resp == del_resp["result"]
+
+    #
 
     # query by event id (none)
     resp = await rc.request(
@@ -453,7 +489,6 @@ async def _delete_manifest(
         },
     )
     assert not resp["scan_ids"]  # no matches
-
     # query by event id w/ incl_del
     resp = await rc.request(
         "GET",
@@ -466,40 +501,6 @@ async def _delete_manifest(
         },
     )
     assert resp["scan_ids"] == [scan_id]
-
-    # query result (still exists)
-    resp = await rc.request("GET", f"/scan/result/{scan_id}")
-    assert resp == last_known_result
-
-
-async def _delete_result(
-    rc: RestClient,
-    scan_id: str,
-    last_known_result: StrDict,
-    is_final: bool,
-) -> None:
-    # delete result
-    resp = await rc.request("DELETE", f"/scan/result/{scan_id}")
-    assert resp == {
-        "scan_id": scan_id,
-        "is_deleted": True,
-        "is_final": is_final,
-        "skyscan_result": last_known_result["skyscan_result"],
-    }
-    del_resp = resp  # keep around
-
-    # query result (fails)
-    with pytest.raises(
-        requests.exceptions.HTTPError,
-        match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/result/{scan_id}"
-        ),
-    ):
-        await rc.request("GET", f"/scan/result/{scan_id}")
-
-    # query w/ incl_del
-    resp = await rc.request("GET", f"/scan/result/{scan_id}", {"include_deleted": True})
-    assert resp == del_resp
 
 
 ########################################################################################
@@ -586,18 +587,13 @@ async def test_00(
     result = await _send_result(rc, scan_id, manifest, True)
     # wait as long as the server, so it'll mark as complete
     await asyncio.sleep(TEST_WAIT_BEFORE_TEARDOWN)
-    manifest = await rc.request("GET", f"/scan/manifest/{scan_id}")
+    manifest = await rc.request("GET", f"/scan/{scan_id}/manifest")
     assert manifest["complete"]
 
     #
-    # DELETE MANIFEST
+    # DELETE SCAN
     #
-    await _delete_manifest(rc, event_metadata, scan_id, manifest, result)
-
-    #
-    # DELETE RESULT
-    #
-    await _delete_result(rc, scan_id, result, True)
+    await _delete_scan(rc, event_metadata, scan_id, manifest, result, True)
 
 
 async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
@@ -723,19 +719,19 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     # with pytest.raises(
     #     requests.exceptions.HTTPError,
     #     match=re.escape(
-    #         f"422 Client Error: Attempted progress update with an empty object ({{}}) for url: {rc.address}/scan/manifest/{scan_id}"
+    #         f"422 Client Error: Attempted progress update with an empty object ({{}}) for url: {rc.address}/scan/{scan_id}/manifest"
     #     ),
     # ) as e:
-    #     await rc.request("PATCH", f"/scan/manifest/{scan_id}", {"progress": {}})
+    #     await rc.request("PATCH", f"/scan/{scan_id}/manifest", {"progress": {}})
     print(e.value)
     # # bad-type body-arg
     for bad_val in ["Done", ["a", "b", "c"]]:  # type: ignore[assignment]
         with pytest.raises(
             requests.exceptions.HTTPError,
-            match=rf"400 Client Error: `progress`: \(ValueError\) missing value for field .* for url: {rc.address}/scan/manifest/{scan_id}",
+            match=rf"400 Client Error: `progress`: \(ValueError\) missing value for field .* for url: {rc.address}/scan/{scan_id}/manifest",
         ) as e:
             await rc.request(
-                "PATCH", f"/scan/manifest/{scan_id}", {"progress": bad_val}
+                "PATCH", f"/scan/{scan_id}/manifest", {"progress": bad_val}
             )
         print(e.value)
 
@@ -788,14 +784,14 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     with pytest.raises(
         requests.exceptions.HTTPError,
         match=re.escape(
-            f"400 Client Error: `skyscan_result`: (MissingArgumentError) required argument is missing for url: {rc.address}/scan/result/{scan_id}"
+            f"400 Client Error: `skyscan_result`: (MissingArgumentError) required argument is missing for url: {rc.address}/scan/{scan_id}/result"
         ),
     ) as e:
-        await rc.request("PUT", f"/scan/result/{scan_id}", {})
+        await rc.request("PUT", f"/scan/{scan_id}/result", {})
     print(e.value)
     # # empty body-arg -- no error, doesn't do anything but return {}
     ret = await rc.request(
-        "PUT", f"/scan/result/{scan_id}", {"skyscan_result": {}, "is_final": True}
+        "PUT", f"/scan/{scan_id}/result", {"skyscan_result": {}, "is_final": True}
     )
     assert ret == {}
     print(e.value)
@@ -804,12 +800,12 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
         with pytest.raises(
             requests.exceptions.HTTPError,
             match=re.escape(
-                f"400 Client Error: `skyscan_result`: (ValueError) type mismatch: 'dict' (value is '{type(bad_val)}') for url: {rc.address}/scan/result/{scan_id}"
+                f"400 Client Error: `skyscan_result`: (ValueError) type mismatch: 'dict' (value is '{type(bad_val)}') for url: {rc.address}/scan/{scan_id}/result"
             ),
         ) as e:
             await rc.request(
                 "PUT",
-                f"/scan/result/{scan_id}",
+                f"/scan/{scan_id}/result",
                 {"skyscan_result": bad_val, "is_final": True},
             )
         print(e.value)
@@ -818,7 +814,7 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     result = await _send_result(rc, scan_id, manifest, True)
     # wait as long as the server, so it'll mark as complete
     await asyncio.sleep(TEST_WAIT_BEFORE_TEARDOWN)
-    manifest = await rc.request("GET", f"/scan/manifest/{scan_id}")
+    manifest = await rc.request("GET", f"/scan/{scan_id}/manifest")
     assert manifest["complete"]
 
     # # no arg
@@ -832,42 +828,20 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     print(e.value)
 
     #
-    # DELETE MANIFEST
+    # DELETE SCAN
     #
 
     # ERROR
     # # no arg
     with pytest.raises(
         requests.exceptions.HTTPError,
-        match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/manifest"
-        ),
+        match=re.escape(f"404 Client Error: Not Found for url: {rc.address}/scan"),
     ) as e:
-        await rc.request("DELETE", "/scan/manifest")
+        await rc.request("DELETE", "/scan")
     print(e.value)
 
     # OK
-    await _delete_manifest(rc, event_metadata, scan_id, manifest, result)
+    await _delete_scan(rc, event_metadata, scan_id, manifest, result, False)
 
     # also OK
-    await _delete_manifest(rc, event_metadata, scan_id, manifest, result)
-
-    #
-    # DELETE RESULT
-    #
-
-    # # no arg
-    with pytest.raises(
-        requests.exceptions.HTTPError,
-        match=re.escape(
-            f"404 Client Error: Not Found for url: {rc.address}/scan/result"
-        ),
-    ) as e:
-        await rc.request("DELETE", "/scan/result")
-    print(e.value)
-
-    # OK
-    await _delete_result(rc, scan_id, result, True)
-
-    # also OK
-    await _delete_result(rc, scan_id, result, True)
+    await _delete_scan(rc, event_metadata, scan_id, manifest, result, False)

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -409,11 +409,12 @@ async def _delete_scan(
     last_known_manifest: StrDict,
     last_known_result: StrDict,
     is_final: bool,
+    delete_completed_scan: bool | None,
 ) -> None:
     # DELETE SCAN
     body = {}
-    if is_final:
-        body["delete_completed_scan"] = True
+    if delete_completed_scan is not None:
+        body["delete_completed_scan"] = delete_completed_scan
     resp = await rc.request("DELETE", f"/scan/{scan_id}", body)
     assert resp == {
         "manifest": {
@@ -591,7 +592,7 @@ async def test_00(
     #
     # DELETE SCAN
     #
-    await _delete_scan(rc, event_metadata, scan_id, manifest, result, True)
+    await _delete_scan(rc, event_metadata, scan_id, manifest, result, True, True)
 
 
 async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
@@ -795,7 +796,7 @@ async def test_01__bad_data(server: Callable[[], RestClient]) -> None:
     print(e.value)
 
     # OK
-    await _delete_scan(rc, event_metadata, scan_id, manifest, result, False)
+    await _delete_scan(rc, event_metadata, scan_id, manifest, result, False, True)
 
     # also OK
-    await _delete_scan(rc, event_metadata, scan_id, manifest, result, False)
+    await _delete_scan(rc, event_metadata, scan_id, manifest, result, False, True)

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -416,15 +416,15 @@ async def _delete_scan(
         body["delete_completed_scan"] = True
     resp = await rc.request("DELETE", f"/scan/{scan_id}", body)
     assert resp == {
-        "manifest": dict(
+        "manifest": {
             **resp["manifest"],
             # only checking these fields:
-            scan_id=scan_id,
-            is_deleted=True,
-            progress=last_known_manifest["progress"],
-            complete=last_known_manifest["complete"],
+            "scan_id": scan_id,
+            "is_deleted": True,
+            "progress": last_known_manifest["progress"],
+            "complete": last_known_manifest["complete"],
             # TODO: check more fields in future (hint: ctrl+F this comment)
-        ),
+        },
         "result": {
             "scan_id": scan_id,
             "is_deleted": True,

--- a/tests/unit/test_sanity.py
+++ b/tests/unit/test_sanity.py
@@ -1,6 +1,7 @@
 """Test that everything is where we think it is."""
 
 import inspect
+from pprint import pprint
 
 from rest_tools.server import RestHandler
 from skydriver import rest_handlers
@@ -40,6 +41,7 @@ def test_00__rest_handlers() -> None:
 
     # search for all known handlers
     for handler, (route, methods) in known_handlers.items():
+        pprint(dir(handler))
         assert all(x in dir(handler) for x in methods)
         assert not any(x in dir(handler) for x in REST_METHODS - set(methods))
         assert handler.ROUTE == route  # type: ignore[attr-defined]  # base type does not have ROUTE

--- a/tests/unit/test_sanity.py
+++ b/tests/unit/test_sanity.py
@@ -1,49 +1,25 @@
 """Test that everything is where we think it is."""
 
 import inspect
-from pprint import pprint
 
 from rest_tools.server import RestHandler
 from skydriver import rest_handlers
-
-REST_METHODS = {"post", "get", "put", "patch", "delete"}
 
 
 def test_00__rest_handlers() -> None:
     """Dir-check all the REST handlers."""
 
     known_handlers = {
-        rest_handlers.MainHandler: (
-            r"/$",
-            ["post"],
-        ),
-        rest_handlers.RunEventMappingHandler: (
-            r"/scans$",
-            ["get"],
-        ),
-        rest_handlers.ScanLauncherHandler: (
-            r"/scan$",
-            ["post"],
-        ),
-        rest_handlers.ScanHandler: (
-            r"/scan/(?P<scan_id>\w+)$",
-            ["get", "delete"],
-        ),
-        rest_handlers.ScanManifestHandler: (
-            r"/scan/(?P<scan_id>\w+)/manifest$",
-            ["get", "patch"],
-        ),
-        rest_handlers.ScanResultHandler: (
-            r"/scan/(?P<scan_id>\w+)/result$",
-            ["get", "put"],
-        ),
+        rest_handlers.MainHandler: r"/$",
+        rest_handlers.RunEventMappingHandler: r"/scans$",
+        rest_handlers.ScanLauncherHandler: r"/scan$",
+        rest_handlers.ScanHandler: r"/scan/(?P<scan_id>\w+)$",
+        rest_handlers.ScanManifestHandler: r"/scan/(?P<scan_id>\w+)/manifest$",
+        rest_handlers.ScanResultHandler: r"/scan/(?P<scan_id>\w+)/result$",
     }
 
     # search for all known handlers
-    for handler, (route, methods) in known_handlers.items():
-        pprint(dir(handler))
-        assert all(x in dir(handler) for x in methods)
-        assert not any(x in dir(handler) for x in REST_METHODS - set(methods))
+    for handler, route in known_handlers.items():
         assert handler.ROUTE == route  # type: ignore[attr-defined]  # base type does not have ROUTE
 
     # find

--- a/tests/unit/test_sanity.py
+++ b/tests/unit/test_sanity.py
@@ -22,13 +22,17 @@ def test_00__rest_handlers() -> None:
             r"/scan$",
             ["post"],
         ),
-        rest_handlers.ManifestHandler: (
-            r"/scan/manifest/(?P<scan_id>\w+)$",
-            ["get", "delete", "patch"],
+        rest_handlers.ScanHandler: (
+            r"/scan/(?P<scan_id>\w+)$",
+            ["get", "delete"],
         ),
-        rest_handlers.ResultsHandler: (
-            r"/scan/result/(?P<scan_id>\w+)$",
-            ["get", "delete", "put"],
+        rest_handlers.ScanManifestHandler: (
+            r"/scan/(?P<scan_id>\w+)/manifest$",
+            ["get", "patch"],
+        ),
+        rest_handlers.ScanResultHandler: (
+            r"/scan/(?P<scan_id>\w+)/result$",
+            ["get", "put"],
         ),
     }
 

--- a/tests/unit/test_sanity.py
+++ b/tests/unit/test_sanity.py
@@ -5,6 +5,8 @@ import inspect
 from rest_tools.server import RestHandler
 from skydriver import rest_handlers
 
+REST_METHODS = {"post", "get", "put", "patch", "delete"}
+
 
 def test_00__rest_handlers() -> None:
     """Dir-check all the REST handlers."""
@@ -39,6 +41,7 @@ def test_00__rest_handlers() -> None:
     # search for all known handlers
     for handler, (route, methods) in known_handlers.items():
         assert all(x in dir(handler) for x in methods)
+        assert not any(x in dir(handler) for x in REST_METHODS - set(methods))
         assert handler.ROUTE == route  # type: ignore[attr-defined]  # base type does not have ROUTE
 
     # find


### PR DESCRIPTION
Adds `/scan/SCANID` for dealing with data at the "scan" level, as opposed to the more granular manifest and/or result-levels

- merges the two previous `DELETE`s into single `/scan/SCANID`'s `DELETE`
- adds `GET` method to `/scan/SCANID`
- renames the manifest and result routes: `/scan/SCANID/manifest` & `/scan/SCANID/result`
	* this 1. indicates that a manifest and result are subordinate to a scan and 2. satisfies to route regex