### PR TITLE
Return Empty Dict For Pending Result

### DIFF
--- a/requirements-clientmanager.txt
+++ b/requirements-clientmanager.txt
@@ -6,9 +6,9 @@
 #
 backoff==2.2.1
     # via opentelemetry-exporter-otlp-proto-http
-boto3==1.26.123
+boto3==1.26.124
     # via UNKNOWN (setup.py)
-botocore==1.29.123
+botocore==1.29.124
     # via
     #   boto3
     #   s3transfer

--- a/requirements-clientmanager.txt
+++ b/requirements-clientmanager.txt
@@ -6,9 +6,9 @@
 #
 backoff==2.2.1
     # via opentelemetry-exporter-otlp-proto-http
-boto3==1.26.120
+boto3==1.26.123
     # via UNKNOWN (setup.py)
-botocore==1.29.120
+botocore==1.29.123
     # via
     #   boto3
     #   s3transfer

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -471,9 +471,18 @@ class ScanResultHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
         """Get a scan's persisted result."""
         incl_del = self.get_argument("include_deleted", default=False, type=bool)
 
-        result = await self.results.get(scan_id, incl_del)
+        # if we don't have a result yet,
+        # see if we have a manifest then return {}, else 404
+        try:
+            result = await self.results.get(scan_id, incl_del)
+            result_dict = dc.asdict(result)
+        except web.HTTPError as e:
+            if e.status_code != 404:
+                raise
+            await self.manifests.get(scan_id, incl_del)  # actually raise 404 if missing
+            result_dict = {}
 
-        self.write(dc.asdict(result))
+        self.write(result_dict)
 
     @service_account_auth(roles=[SKYMAP_SCANNER_ACCT])  # type: ignore
     async def put(self, scan_id: str) -> None:

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -376,7 +376,7 @@ class ScanHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
         """Get manifest & result."""
         incl_del = self.get_argument("include_deleted", default=False, type=bool)
 
-        manifest = await self.manifests.get(scan_id, incl_del)
+        manifest = await self.manifests.get(scan_id, incl_del)  # 404 if missing
 
         # if we don't have a result yet, return {}
         try:

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -377,12 +377,20 @@ class ScanHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
         incl_del = self.get_argument("include_deleted", default=False, type=bool)
 
         manifest = await self.manifests.get(scan_id, incl_del)
-        result = await self.results.get(scan_id, incl_del)
+
+        # if we don't have a result yet, return {}
+        try:
+            result = await self.results.get(scan_id, incl_del)
+            result_dict = dc.asdict(result)
+        except web.HTTPError as e:
+            if e.status_code != 404:
+                raise
+            result_dict = {}
 
         self.write(
             {
                 "manifest": dc.asdict(manifest),
-                "result": dc.asdict(result),
+                "result": result_dict,
             }
         )
 

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -589,8 +589,10 @@ async def test_00(
         },
         docker_tag_input_and_expect[1],
     )
+    assert await rc.request("GET", f"/scan/{scan_id}/result") == {}
     event_metadata = await _server_reply_with_event_metadata(rc, scan_id)
     manifest = await _clientmanager_reply(rc, scan_id, [])
+    assert await rc.request("GET", f"/scan/{scan_id}/result") == {}
 
     #
     # ADD PROGRESS


### PR DESCRIPTION
Previously, requesting a pending result (a scan with a manifest but not yet a result) would return a 404.

Now, return `{}`. Applies to `/scan/SCAN_ID - GET` and `/scan/SCAN_ID/result - GET`