### PR TITLE
User-Defined `classifiers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ _Launch a new scan of an event_
 | `"memory"`                        | str          | default: `8G`   | how much memory per client worker to request
 | `"predictive_scanning_threshold"` | float        | default: `1.0`   | the predictive scanning threshold [0.1, 1.0] (see [Skymap Scanner](https://github.com/icecube/skymap_scanner))
 | `"max_pixel_reco_time"`           | int          | default: `None`  | the max amount of time each pixel's reco should take
+| `"classifiers"` | `dict[str, str | bool | float | int]` | default: `{}` | a user-defined collection of labels, attributes, etc. -- this is constrained in size and is intended for user-defined metadata only
 | `"manifest_projection"` | list | default: all fields but [these](#manifest-fields-excluded-by-default-in-response) | which `Manifest` fields to include in the response (include `*` to include all fields)
 
 
@@ -270,6 +271,8 @@ Pseudo-code:
     scanner_server_args: str,
     tms_args: list[str],
     env_vars: dict[str, dict[str, Any]],
+
+    classifiers: dict[str, str | bool | float | int]
 
     event_i3live_json_dict__hash: str,  # a deterministic hash of the event json
 

--- a/dependencies-from-Dockerfile.log
+++ b/dependencies-from-Dockerfile.log
@@ -1,6 +1,6 @@
 backoff==2.2.1
-boto3==1.28.48
-botocore==1.31.48
+boto3==1.28.49
+botocore==1.31.49
 cachetools==5.3.1
 certifi==2023.7.22
 cffi==1.15.1

--- a/dependencies-from-Dockerfile.log
+++ b/dependencies-from-Dockerfile.log
@@ -1,6 +1,6 @@
 backoff==2.2.1
-boto3==1.28.46
-botocore==1.31.46
+boto3==1.28.48
+botocore==1.31.48
 cachetools==5.3.1
 certifi==2023.7.22
 cffi==1.15.1
@@ -13,7 +13,7 @@ dnspython==2.4.2
 google-auth==2.23.0
 googleapis-common-protos==1.56.2
 grpcio==1.58.0
-htcondor==10.7.0
+htcondor==10.8.0
 humanfriendly==10.0
 idna==3.4
 importlib-metadata==6.8.0

--- a/skydriver/database/interface.py
+++ b/skydriver/database/interface.py
@@ -60,7 +60,7 @@ class ManifestClient:
         scanner_server_args: str,
         tms_args_list: list[str],
         env_vars: dict[str, Any],
-        keywords: list,
+        classifiers: list,
     ) -> schema.Manifest:
         """Create `schema.Manifest` doc."""
         LOGGER.debug("creating new manifest")
@@ -74,7 +74,7 @@ class ManifestClient:
             scanner_server_args=scanner_server_args,
             tms_args=tms_args_list,
             env_vars=env_vars,
-            keywords=keywords,
+            classifiers=classifiers,
         )
 
         # db

--- a/skydriver/database/interface.py
+++ b/skydriver/database/interface.py
@@ -60,6 +60,7 @@ class ManifestClient:
         scanner_server_args: str,
         tms_args_list: list[str],
         env_vars: dict[str, Any],
+        keywords: list,
     ) -> schema.Manifest:
         """Create `schema.Manifest` doc."""
         LOGGER.debug("creating new manifest")
@@ -73,6 +74,7 @@ class ManifestClient:
             scanner_server_args=scanner_server_args,
             tms_args=tms_args_list,
             env_vars=env_vars,
+            keywords=keywords,
         )
 
         # db

--- a/skydriver/database/interface.py
+++ b/skydriver/database/interface.py
@@ -60,7 +60,7 @@ class ManifestClient:
         scanner_server_args: str,
         tms_args_list: list[str],
         env_vars: dict[str, Any],
-        classifiers: list,
+        classifiers: dict[str, str | bool | float | int],
     ) -> schema.Manifest:
         """Create `schema.Manifest` doc."""
         LOGGER.debug("creating new manifest")

--- a/skydriver/database/schema.py
+++ b/skydriver/database/schema.py
@@ -150,6 +150,8 @@ class Manifest(ScanIDDataclass):
     tms_args: list[str]
     env_vars: dict[str, Any]
 
+    keywords: list[str] = dc.field(default_factory=list)
+
     # special fields -- see __post_init__
     event_i3live_json_dict__hash: str = ""  # possibly overwritten
 

--- a/skydriver/database/schema.py
+++ b/skydriver/database/schema.py
@@ -150,7 +150,7 @@ class Manifest(ScanIDDataclass):
     tms_args: list[str]
     env_vars: dict[str, Any]
 
-    keywords: list[str] = dc.field(default_factory=list)
+    classifiers: list[str] = dc.field(default_factory=list)
 
     # special fields -- see __post_init__
     event_i3live_json_dict__hash: str = ""  # possibly overwritten

--- a/skydriver/database/schema.py
+++ b/skydriver/database/schema.py
@@ -150,7 +150,7 @@ class Manifest(ScanIDDataclass):
     tms_args: list[str]
     env_vars: dict[str, Any]
 
-    classifiers: list[str] = dc.field(default_factory=list)
+    classifiers: dict[str, str | bool | float | int] = dc.field(default_factory=dict)
 
     # special fields -- see __post_init__
     event_i3live_json_dict__hash: str = ""  # possibly overwritten

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -340,6 +340,7 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
         keywords = self.get_argument(
             "keywords",
             type=list,  # TODO -- put data size constraints
+            strict_type=True,
             default=[],
         )
 

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -368,7 +368,7 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
         classifiers = self.get_argument(
             "classifiers",
             type=_classifiers_validator,
-            default=[],
+            default={},
         )
 
         # response args

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -336,6 +336,13 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
             default=False,
         )
 
+        # other args
+        keywords = self.get_argument(
+            "keywords",
+            type=list,  # TODO -- put data size constraints
+            default=[],
+        )
+
         # response args
         manifest_projection = self.get_argument(
             "manifest_projection",
@@ -379,6 +386,7 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
             k8s_job.scanner_server_args,
             k8s_job.tms_args_list,
             k8s_job.env_dict,
+            keywords,
         )
 
         # enqueue skymap scanner instance to be started in-time

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -337,8 +337,8 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
         )
 
         # other args
-        keywords = self.get_argument(
-            "keywords",
+        classifiers = self.get_argument(
+            "classifiers",
             type=list,  # TODO -- put data size constraints
             strict_type=True,
             default=[],
@@ -387,7 +387,7 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
             k8s_job.scanner_server_args,
             k8s_job.tms_args_list,
             k8s_job.env_dict,
-            keywords,
+            classifiers,
         )
 
         # enqueue skymap scanner instance to be started in-time

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -35,6 +35,13 @@ POST_SCAN_BODY = {
     "docker_tag": "latest",
     "keywords": KEYWORDS,
 }
+REQUIRED_FIELDS = [
+    "reco_algo",
+    "event_i3live_json",
+    "nsides",
+    "real_or_simulated_event",
+    "docker_tag",
+]
 
 
 ########################################################################################
@@ -775,16 +782,18 @@ async def test_01__bad_data(
     print(e.value)
     # # missing arg
     for arg in POST_SCAN_BODY_FOR_TEST_01:
-        with pytest.raises(
-            requests.exceptions.HTTPError,
-            match=rf"400 Client Error: `{arg}`: \(MissingArgumentError\) required argument is missing for url: {rc.address}/scan",
-        ) as e:
-            # remove arg from body
-            await rc.request(
-                "POST",
-                "/scan",
-                {k: v for k, v in POST_SCAN_BODY_FOR_TEST_01.items() if k != arg},
-            )
+        if arg in REQUIRED_FIELDS:
+            print(arg)
+            with pytest.raises(
+                requests.exceptions.HTTPError,
+                match=rf"400 Client Error: `{arg}`: \(MissingArgumentError\) required argument is missing for url: {rc.address}/scan",
+            ) as e:
+                # remove arg from body
+                await rc.request(
+                    "POST",
+                    "/scan",
+                    {k: v for k, v in POST_SCAN_BODY_FOR_TEST_01.items() if k != arg},
+                )
         print(e.value)
     # # bad docker tag
     with pytest.raises(

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -26,14 +26,14 @@ StrDict = dict[str, Any]
 
 IS_REAL_EVENT = True  # for simplicity, hardcode for all requests
 
-KEYWORDS = ["foo", "bar bat", "baz"]
+CLASSIFIERS = ["foo", "bar bat", "baz"]
 POST_SCAN_BODY = {
     "reco_algo": "anything",
     "event_i3live_json": {"a": 22},
     "nsides": {1: 2, 3: 4},
     "real_or_simulated_event": "real",
     "docker_tag": "latest",
-    "keywords": KEYWORDS,
+    "classifiers": CLASSIFIERS,
 }
 REQUIRED_FIELDS = [
     "reco_algo",
@@ -88,7 +88,7 @@ async def _launch_scan(
         tms_args=resp["tms_args"],  # see below
         env_vars=resp["env_vars"],  # see below
         complete=False,
-        keywords=post_scan_body["keywords"],
+        classifiers=post_scan_body["classifiers"],
         # TODO: check more fields in future (hint: ctrl+F this comment)
     )
 
@@ -252,7 +252,7 @@ async def _do_patch(
         scanner_server_args=resp["scanner_server_args"],  # not checking
         tms_args=resp["tms_args"],  # not checking
         complete=False,
-        keywords=KEYWORDS,
+        classifiers=CLASSIFIERS,
         # TODO: check more fields in future (hint: ctrl+F this comment)
     )
     assert 0.0 < resp["timestamp"] < time.time()

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -26,13 +26,14 @@ StrDict = dict[str, Any]
 
 IS_REAL_EVENT = True  # for simplicity, hardcode for all requests
 
-
+KEYWORDS = ["foo", "bar bat", "baz"]
 POST_SCAN_BODY = {
     "reco_algo": "anything",
     "event_i3live_json": {"a": 22},
     "nsides": {1: 2, 3: 4},
     "real_or_simulated_event": "real",
     "docker_tag": "latest",
+    "keywords": KEYWORDS,
 }
 
 
@@ -80,6 +81,7 @@ async def _launch_scan(
         tms_args=resp["tms_args"],  # see below
         env_vars=resp["env_vars"],  # see below
         complete=False,
+        keywords=post_scan_body["keywords"],
         # TODO: check more fields in future (hint: ctrl+F this comment)
     )
 
@@ -243,6 +245,7 @@ async def _do_patch(
         scanner_server_args=resp["scanner_server_args"],  # not checking
         tms_args=resp["tms_args"],  # not checking
         complete=False,
+        keywords=KEYWORDS,
         # TODO: check more fields in future (hint: ctrl+F this comment)
     )
     assert 0.0 < resp["timestamp"] < time.time()

--- a/tests/integration/test_rest_routes.py
+++ b/tests/integration/test_rest_routes.py
@@ -26,7 +26,12 @@ StrDict = dict[str, Any]
 
 IS_REAL_EVENT = True  # for simplicity, hardcode for all requests
 
-CLASSIFIERS = ["foo", "bar bat", "baz"]
+CLASSIFIERS = {
+    "foo": 1,
+    "bar bat": True,
+    "baz": "y" * skydriver.rest_handlers.MAX_CLASSIFIERS_LEN,  # type: ignore[attr-defined]
+    "z" * skydriver.rest_handlers.MAX_CLASSIFIERS_LEN: 3.1415,  # type: ignore[attr-defined]
+}
 POST_SCAN_BODY = {
     "reco_algo": "anything",
     "event_i3live_json": {"a": 22},


### PR DESCRIPTION
Adds a user-defined `classifiers` field, a dictionary (`dict[str, str | bool | float | int]`). The structure is constrained in size to a max of 15 subfields, 15-character long keys, and 15-character long subfields (if a string).

This is given on a `scan/` POST and is stored in the Manifest.

closes https://github.com/WIPACrepo/SkyDriver/issues/69