### PR TITLE
Make Retrieving Pod Statuses Optional for `/scan/SCAN_ID/status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,10 @@ None
 _Retrieve the status of a scan_
 
 #### Arguments
-None
+| Argument                 | Type    | Required/Default | Description          |
+| ------------------------ | ------- | ---------------- | -------------------- |
+| `"include_pod_statuses"` | bool    | `False`          | whether to include the k8s pod statuses for the clientmanager & central server -- expends additional resources
+
 
 #### SkyDriver Effects
 None
@@ -228,8 +231,10 @@ None
     "scan_state": str,  # a short human-readable code
     "is_deleted": bool,
     "scan_complete": bool,  # skymap scanner finished
-    "pod_status": dict,  # a large k8s status object
-    "pod_status_message": str,  # a human-readable message explaining the pod status retrieval
+    "pods": {  # field is included only if `include_pod_statuses == True`
+        "pod_status": dict,  # a large k8s status object
+        "pod_status_message": str,  # a human-readable message explaining the pod status retrieval
+    }
     "clusters": list,  # same as Manifest's clusters field
 }
 ```

--- a/dependencies-from-Dockerfile.log
+++ b/dependencies-from-Dockerfile.log
@@ -14,7 +14,7 @@ certifi==2023.11.17
 cffi==1.16.0
 charset-normalizer==3.3.2
 coloredlogs==15.0.1
-cryptography==41.0.5
+cryptography==41.0.6
 dacite==1.8.1
 Deprecated==1.2.14
 dnspython==2.4.2
@@ -68,7 +68,7 @@ zipp==3.17.0
 ########################################################################
 #  pipdeptree
 ########################################################################
-cryptography==41.0.5
+cryptography==41.0.6
 └── cffi [required: >=1.12, installed: 1.16.0]
     └── pycparser [required: Any, installed: 2.21]
 pip==23.2.1


### PR DESCRIPTION
It costs additional resources to grab the k8s pod statuses. Since we want to use this route for https://github.com/icecube/skymap_scanner/issues/238 and don't need info on pods, this PR makes this part optional and turned off by default.