### PR TITLE
Add Optional `"skyscan_mq_client_timeout_wait_for_first_message"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ _Launch a new scan of an event_
 | `"nsides"`                        | dict         | *[REQUIRED]*     | the nside progression to use (see [Skymap Scanner](https://github.com/icecube/skymap_scanner))
 | `"real_or_simulated_event"`       | str          | *[REQUIRED]*     | whether this event is real or simulated. Ex: `real`, `simulated`
 | `"max_pixel_reco_time"`           | int          | *[REQUIRED]*     | the max amount of time each pixel's reco should take (accurate values will evict pixels from slow workers thereby re-delivering to faster workers -- slow workers are unavoidable due to non-deterministic errors)
-| `"skyscan_mq_client_timeout_wait_for_first_message"` | int | default: None | how long a client can wait for its first message (pixel) before giving up and exiting
+| `"skyscan_mq_client_timeout_wait_for_first_message"` | int | default: image's default value | how long a client can wait for its first message (pixel) before giving up and exiting
 | `"scanner_server_memory"`         | str          | default: `1024M` | how much memory for the scanner server to request
 | `"memory"`                        | str          | default: `8G`   | how much memory per client worker to request
 | `"debug_mode"`                    | str or list  | default: None    | what debug mode(s) to use: `"client-logs"` collects the scanner clients' stderr/stdout including icetray logs (scans are limited in # of workers)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ _Launch a new scan of an event_
 | `"nsides"`                        | dict         | *[REQUIRED]*     | the nside progression to use (see [Skymap Scanner](https://github.com/icecube/skymap_scanner))
 | `"real_or_simulated_event"`       | str          | *[REQUIRED]*     | whether this event is real or simulated. Ex: `real`, `simulated`
 | `"max_pixel_reco_time"`           | int          | *[REQUIRED]*     | the max amount of time each pixel's reco should take (accurate values will evict pixels from slow workers thereby re-delivering to faster workers -- slow workers are unavoidable due to non-deterministic errors)
+| `"skyscan_mq_client_timeout_wait_for_first_message"` | int | default: None | how long a client can wait for its first message (pixel) before giving up and exiting
 | `"scanner_server_memory"`         | str          | default: `1024M` | how much memory for the scanner server to request
 | `"memory"`                        | str          | default: `8G`   | how much memory per client worker to request
 | `"debug_mode"`                    | str or list  | default: None    | what debug mode(s) to use: `"client-logs"` collects the scanner clients' stderr/stdout including icetray logs (scans are limited in # of workers)

--- a/dependencies-from-Dockerfile.log
+++ b/dependencies-from-Dockerfile.log
@@ -7,14 +7,14 @@
 #  pip freeze
 ########################################################################
 backoff==2.2.1
-boto3==1.29.7
-botocore==1.32.7
+boto3==1.33.2
+botocore==1.33.2
 cachetools==5.3.2
 certifi==2023.11.17
 cffi==1.16.0
 charset-normalizer==3.3.2
 coloredlogs==15.0.1
-cryptography==41.0.6
+cryptography==41.0.7
 dacite==1.8.1
 Deprecated==1.2.14
 dnspython==2.4.2
@@ -52,7 +52,7 @@ requests==2.31.0
 requests-futures==1.0.1
 requests-oauthlib==1.3.1
 rsa==4.9
-s3transfer==0.8.0
+s3transfer==0.8.1
 six==1.16.0
 thrift==0.16.0
 tornado==6.3.3
@@ -68,22 +68,22 @@ zipp==3.17.0
 ########################################################################
 #  pipdeptree
 ########################################################################
-cryptography==41.0.6
+cryptography==41.0.7
 └── cffi [required: >=1.12, installed: 1.16.0]
     └── pycparser [required: Any, installed: 2.21]
 pip==23.2.1
 pipdeptree==2.13.1
 setuptools==65.5.1
 skydriver-clientmanager
-├── boto3 [required: Any, installed: 1.29.7]
-│   ├── botocore [required: >=1.32.7,<1.33.0, installed: 1.32.7]
+├── boto3 [required: Any, installed: 1.33.2]
+│   ├── botocore [required: >=1.33.2,<1.34.0, installed: 1.33.2]
 │   │   ├── jmespath [required: >=0.7.1,<2.0.0, installed: 1.0.1]
 │   │   ├── python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.2]
 │   │   │   └── six [required: >=1.5, installed: 1.16.0]
 │   │   └── urllib3 [required: >=1.25.4,<2.1, installed: 1.26.18]
 │   ├── jmespath [required: >=0.7.1,<2.0.0, installed: 1.0.1]
-│   └── s3transfer [required: >=0.8.0,<0.9.0, installed: 0.8.0]
-│       └── botocore [required: >=1.32.7,<2.0a.0, installed: 1.32.7]
+│   └── s3transfer [required: >=0.8.0,<0.9.0, installed: 0.8.1]
+│       └── botocore [required: >=1.33.2,<2.0a.0, installed: 1.33.2]
 │           ├── jmespath [required: >=0.7.1,<2.0.0, installed: 1.0.1]
 │           ├── python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.2]
 │           │   └── six [required: >=1.5, installed: 1.16.0]

--- a/skydriver/k8s/scanner_instance.py
+++ b/skydriver/k8s/scanner_instance.py
@@ -6,7 +6,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-import kubernetes.client  # type: ignore[import]
+import kubernetes.client  # type: ignore[import-untyped]
 from rest_tools.client import ClientCredentialsAuth
 
 from .. import database, images
@@ -79,6 +79,7 @@ class SkymapScannerJob:
         debug_mode: list[DebugMode],
         # env
         rest_address: str,
+        skyscan_mq_client_timeout_wait_for_first_message: int | None,
     ):
         LOGGER.info(f"making k8s job for {scan_id=}")
         self.k8s_batch_api = k8s_batch_api
@@ -102,6 +103,7 @@ class SkymapScannerJob:
             self.make_skyscan_server_v1envvars(
                 rest_address=rest_address,
                 scan_id=scan_id,
+                skyscan_mq_client_timeout_wait_for_first_message=skyscan_mq_client_timeout_wait_for_first_message,
             ),
             self.scanner_server_args.split(),
             cpu=1,
@@ -246,6 +248,7 @@ class SkymapScannerJob:
     def make_skyscan_server_v1envvars(
         rest_address: str,
         scan_id: str,
+        skyscan_mq_client_timeout_wait_for_first_message: int | None,
     ) -> list[kubernetes.client.V1EnvVar]:
         """Get the environment variables provided to the skyscan server.
 
@@ -281,6 +284,7 @@ class SkymapScannerJob:
             "SKYSCAN_MQ_TIMEOUT_FROM_CLIENTS": ENV.SKYSCAN_MQ_TIMEOUT_FROM_CLIENTS,
             "SKYSCAN_LOG": ENV.SKYSCAN_LOG,
             "SKYSCAN_LOG_THIRD_PARTY": ENV.SKYSCAN_LOG_THIRD_PARTY,
+            "SKYSCAN_MQ_CLIENT_TIMEOUT_WAIT_FOR_FIRST_MESSAGE": skyscan_mq_client_timeout_wait_for_first_message,
         }
         env.extend(
             [

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -358,12 +358,14 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
             "max_pixel_reco_time",
             type=int,
         )
-        skyscan_mq_client_timeout_wait_for_first_message = self.get_argument(
+        skyscan_mq_client_timeout_wait_for_first_message: int | None = self.get_argument(
             # TODO - remove when TMS is handling workforce-scaling
             "skyscan_mq_client_timeout_wait_for_first_message",
             type=int,
-            default=None,
+            default=-1,  # elephant in Cairo
         )
+        if skyscan_mq_client_timeout_wait_for_first_message == -1:
+            skyscan_mq_client_timeout_wait_for_first_message = None
         debug_mode = self.get_argument(
             "debug_mode",
             type=_debug_mode,

--- a/skydriver/rest_handlers.py
+++ b/skydriver/rest_handlers.py
@@ -358,6 +358,12 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
             "max_pixel_reco_time",
             type=int,
         )
+        skyscan_mq_client_timeout_wait_for_first_message = self.get_argument(
+            # TODO - remove when TMS is handling workforce-scaling
+            "skyscan_mq_client_timeout_wait_for_first_message",
+            type=int,
+            default=None,
+        )
         debug_mode = self.get_argument(
             "debug_mode",
             type=_debug_mode,
@@ -420,6 +426,7 @@ class ScanLauncherHandler(BaseSkyDriverHandler):  # pylint: disable=W0223
             debug_mode=debug_mode,
             # env
             rest_address=self.request.full_url().rstrip(self.request.uri),
+            skyscan_mq_client_timeout_wait_for_first_message=skyscan_mq_client_timeout_wait_for_first_message,
         )
 
         # put in db (do before k8s start so if k8s fail, we can debug using db's info)


### PR DESCRIPTION
This will allow the cluster to remain large despite an initially small nside (in terms of its number of pixels).

_**NOTE - this will be removed once TMS is up and running. IOW, TMS's automated cluster scaling will make this obsolete.**_