### PR TITLE
Fix Backlog Speed [fix]

### DIFF
--- a/dependencies-docker-skydriver.log
+++ b/dependencies-docker-skydriver.log
@@ -6,9 +6,9 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-boto3==1.36.1
-botocore==1.36.1
-cachetools==5.5.0
+boto3==1.36.7
+botocore==1.36.7
+cachetools==5.5.1
 certifi==2024.12.14
 cffi==1.17.1
 charset-normalizer==3.4.1
@@ -16,12 +16,12 @@ cryptography==44.0.0
 dacite==1.8.1
 dnspython==2.7.0
 durationpy==0.9
-google-auth==2.37.0
+google-auth==2.38.0
 htcondor==24.3.0
 humanfriendly==10.0
 idna==3.10
 jmespath==1.0.1
-kubernetes==31.0.0
+kubernetes==32.0.0
 motor==3.3.2
 oauthlib==3.2.2
 pyasn1==0.6.1
@@ -36,14 +36,14 @@ requests==2.32.3
 requests-futures==1.0.2
 requests-oauthlib==2.0.0
 rsa==4.9
-s3transfer==0.11.1
+s3transfer==0.11.2
 six==1.17.0
 tornado==6.4.2
 typeguard==4.4.1
 typing_extensions==4.12.2
 urllib3==2.3.0
 websocket-client==1.8.0
-wipac-dev-tools==1.15.0
+wipac-dev-tools==1.15.1
 wipac-rest-tools==1.8.5
 ########################################################################
 #  pipdeptree
@@ -51,20 +51,20 @@ wipac-rest-tools==1.8.5
 cryptography==44.0.0
 └── cffi [required: >=1.12, installed: 1.17.1]
     └── pycparser [required: Any, installed: 2.22]
-pipdeptree==2.24.0
+pipdeptree==2.25.0
 ├── packaging [required: >=24.1, installed: 24.2]
-└── pip [required: >=24.2, installed: 24.3.1]
+└── pip [required: >=24.2, installed: 25.0]
 setuptools==65.5.1
 skydriver-clientmanager-ewms-sidecar
-├── boto3 [required: Any, installed: 1.36.1]
-│   ├── botocore [required: >=1.36.1,<1.37.0, installed: 1.36.1]
+├── boto3 [required: Any, installed: 1.36.7]
+│   ├── botocore [required: >=1.36.7,<1.37.0, installed: 1.36.7]
 │   │   ├── jmespath [required: >=0.7.1,<2.0.0, installed: 1.0.1]
 │   │   ├── python-dateutil [required: >=2.1,<3.0.0, installed: 2.9.0.post0]
 │   │   │   └── six [required: >=1.5, installed: 1.17.0]
 │   │   └── urllib3 [required: >=1.25.4,<3,!=2.2.0, installed: 2.3.0]
 │   ├── jmespath [required: >=0.7.1,<2.0.0, installed: 1.0.1]
-│   └── s3transfer [required: >=0.11.0,<0.12.0, installed: 0.11.1]
-│       └── botocore [required: >=1.36.0,<2.0a.0, installed: 1.36.1]
+│   └── s3transfer [required: >=0.11.0,<0.12.0, installed: 0.11.2]
+│       └── botocore [required: >=1.36.0,<2.0a.0, installed: 1.36.7]
 │           ├── jmespath [required: >=0.7.1,<2.0.0, installed: 1.0.1]
 │           ├── python-dateutil [required: >=2.1,<3.0.0, installed: 2.9.0.post0]
 │           │   └── six [required: >=1.5, installed: 1.17.0]
@@ -72,11 +72,11 @@ skydriver-clientmanager-ewms-sidecar
 ├── dacite [required: Any, installed: 1.8.1]
 ├── htcondor [required: Any, installed: 24.3.0]
 ├── humanfriendly [required: Any, installed: 10.0]
-├── kubernetes [required: Any, installed: 31.0.0]
+├── kubernetes [required: Any, installed: 32.0.0]
 │   ├── certifi [required: >=14.05.14, installed: 2024.12.14]
 │   ├── durationpy [required: >=0.7, installed: 0.9]
-│   ├── google-auth [required: >=1.0.1, installed: 2.37.0]
-│   │   ├── cachetools [required: >=2.0.0,<6.0, installed: 5.5.0]
+│   ├── google-auth [required: >=1.0.1, installed: 2.38.0]
+│   │   ├── cachetools [required: >=2.0.0,<6.0, installed: 5.5.1]
 │   │   ├── pyasn1_modules [required: >=0.2.1, installed: 0.4.1]
 │   │   │   └── pyasn1 [required: >=0.4.6,<0.7.0, installed: 0.6.1]
 │   │   └── rsa [required: >=3.1.4,<5, installed: 4.9]
@@ -113,7 +113,7 @@ skydriver-clientmanager-ewms-sidecar
 ├── tornado [required: Any, installed: 6.4.2]
 ├── typeguard [required: Any, installed: 4.4.1]
 │   └── typing_extensions [required: >=4.10.0, installed: 4.12.2]
-├── wipac-dev-tools [required: Any, installed: 1.15.0]
+├── wipac-dev-tools [required: Any, installed: 1.15.1]
 │   ├── requests [required: Any, installed: 2.32.3]
 │   │   ├── certifi [required: >=2017.4.17, installed: 2024.12.14]
 │   │   ├── charset-normalizer [required: >=2,<4, installed: 3.4.1]
@@ -121,7 +121,7 @@ skydriver-clientmanager-ewms-sidecar
 │   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.3.0]
 │   └── typing_extensions [required: Any, installed: 4.12.2]
 └── wipac-rest-tools [required: Any, installed: 1.8.5]
-    ├── cachetools [required: Any, installed: 5.5.0]
+    ├── cachetools [required: Any, installed: 5.5.1]
     ├── PyJWT [required: !=2.6.0, installed: 2.10.1]
     ├── qrcode [required: Any, installed: 8.0]
     ├── requests [required: Any, installed: 2.32.3]
@@ -137,7 +137,7 @@ skydriver-clientmanager-ewms-sidecar
     │       └── urllib3 [required: >=1.21.1,<3, installed: 2.3.0]
     ├── tornado [required: Any, installed: 6.4.2]
     ├── urllib3 [required: >=2.0.4, installed: 2.3.0]
-    └── wipac-dev-tools [required: Any, installed: 1.15.0]
+    └── wipac-dev-tools [required: Any, installed: 1.15.1]
         ├── requests [required: Any, installed: 2.32.3]
         │   ├── certifi [required: >=2017.4.17, installed: 2024.12.14]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.4.1]

--- a/skydriver/k8s/scan_backlog.py
+++ b/skydriver/k8s/scan_backlog.py
@@ -199,3 +199,6 @@ async def _run(
 
         # remove from backlog now that startup succeeded
         await scan_backlog.remove(entry)
+        await asyncio.sleep(  # wait so to not overwhelm resources (also, see `sleep()` at top)
+            ENV.SCAN_BACKLOG_RUNNER_DELAY - ENV.SCAN_BACKLOG_RUNNER_SHORT_DELAY
+        )


### PR DESCRIPTION
This PR fixes a bug introduced in the last release, which caused the backlog daemon to run too quickly. Instead of waiting 5 mins between scan starts, the daemon waited 15 seconds. These are the default values, but these are configurable as environment variables.